### PR TITLE
Compatibility updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 **Warning** - *This project is still in its initial development, so use at your own risk.  For details on areas that may still require attention before the project is fully complete please see the* [To Do List](./docs/ToDo.MD)
 
-This project is inspired by, and provides an alternate implementation of, the awesome [node-flint](https://github.com/flint-bot/flint/) framework by [Nick Marus](https://github.com/nmarus).  The framework makes it easy to quickly develop a Webex Teams bot, abstractig away some of the complexity of Webex For Developers interfaces, such as registering for events and calling REST APIs. A bot developer can use the framework to spark their imagination and focus primarily on how the bot will interact with users in Webex Teams.
+This project is inspired by, and provides an alternate implementation of, the awesome [node-flint](https://github.com/flint-bot/flint/) framework by [Nick Marus](https://github.com/nmarus).  The framework makes it easy to quickly develop a Webex Teams bot, abstracting away some of the complexity of Webex For Developers interfaces, such as registering for events and calling REST APIs. A bot developer can use the framework to spark their imagination and focus primarily on how the bot will interact with users in Webex Teams.
 
 The primary change in this implementation is that it is based on the [webex-jssdk](https://webex.github.io/webex-js-sdk) which continues to be supported as new features and functionality are added to Webex.  
 
@@ -401,15 +401,6 @@ Options Object
 | [webhookUrl] | <code>string</code> |  | URL that is used for Webex API to send callbacks.  If not set events are received via websocket |
 | [webhookSecret] | <code>string</code> |  | If specified, inbound webhooks are authorized before being processed. Ignored if webhookUrl is not set. |
 | [messageFormat] | <code>string</code> | <code>&quot;text&quot;</code> | Default Webex message format to use with bot.say(). |
-| [maxPageItems] | <code>number</code> | <code>50</code> | Max results that the paginator uses. |
-| [maxConcurrent] | <code>number</code> | <code>3</code> | Max concurrent sessions to the Webex API |
-| [minTime] | <code>number</code> | <code>600</code> | Min time between consecutive request starts. |
-| [requeueMinTime] | <code>number</code> | <code>minTime*10</code> | Min time between consecutive request starts of requests that have been re-queued. |
-| [requeueMaxRetry] | <code>number</code> | <code>3</code> | Msx number of atteempts to make for failed request. |
-| [requeueCodes] | <code>array</code> | <code>[429,500,503]</code> | Array of http result codes that should be retried. |
-| [requestTimeout] | <code>number</code> | <code>20000</code> | Timeout for an individual request recieving a response. |
-| [queueSize] | <code>number</code> | <code>10000</code> | Size of the buffer that holds outbound requests. |
-| [requeueSize] | <code>number</code> | <code>10000</code> | Size of the buffer that holds outbound re-queue requests. |
 | [id] | <code>string</code> | <code>&quot;random&quot;</code> | The id this instance of Framework uses. |
 | [webhookRequestJSONLocation] | <code>string</code> | <code>&quot;body&quot;</code> | The property under the Request to find the JSON contents. |
 | [removeWebhooksOnStart] | <code>Boolean</code> | <code>true</code> | If you wish to have the bot remove all account webhooks when starting. Ignored if webhookUrl is not set. |

--- a/docs/header.md
+++ b/docs/header.md
@@ -4,7 +4,7 @@
 
 **Warning** - *This project is still in its initial development, so use at your own risk.  For details on areas that may still require attention before the project is fully complete please see the* [To Do List](./docs/ToDo.MD)
 
-This project is inspired by, and provides an alternate implementation of, the awesome [node-flint](https://github.com/flint-bot/flint/) framework by [Nick Marus](https://github.com/nmarus).  The framework makes it easy to quickly develop a Webex Teams bot, abstractig away some of the complexity of Webex For Developers interfaces, such as registering for events and calling REST APIs. A bot developer can use the framework to spark their imagination and focus primarily on how the bot will interact with users in Webex Teams.
+This project is inspired by, and provides an alternate implementation of, the awesome [node-flint](https://github.com/flint-bot/flint/) framework by [Nick Marus](https://github.com/nmarus).  The framework makes it easy to quickly develop a Webex Teams bot, abstracting away some of the complexity of Webex For Developers interfaces, such as registering for events and calling REST APIs. A bot developer can use the framework to spark their imagination and focus primarily on how the bot will interact with users in Webex Teams.
 
 The primary change in this implementation is that it is based on the [webex-jssdk](https://webex.github.io/webex-js-sdk) which continues to be supported as new features and functionality are added to Webex.  
 

--- a/docs/migrate-from-node-flint.md
+++ b/docs/migrate-from-node-flint.md
@@ -34,6 +34,22 @@ var flint = new Framework(config);
 ```
 Naming the new Framework object `flint`, allows existing `flint.hears()` and `flint.on()` functions to behave as the currently do.  
 
+## Missing functionality
+Not all of the functionality in flint has been migrated to the new framework.  Apps that rely on any of the following may wish to postpone their migration (or look to implement these features some other way):
+
+* Retry logic for pagination and rate limiting.  The philosopy behind the framework is to encourage developers to leverage the Webex SDK (exposed as an element in the frameowrk and bot objects), natively when needed.   When appropriate applications should inspect the reponse headers for pagination and rate limiting (HTTP 429 Response Code) as needed.  `framework.start()` will fail when the framework was passed a config object that includes any of the following options:
+     * @property {number} [maxPageItems=50] - Max results that the paginator uses.
+   * @property {number} [maxConcurrent=3] - Max concurrent sessions to the Webex API
+   * @property {number} [minTime=600] - Min time between consecutive request starts.
+   * @property {number} [requeueMinTime=minTime*10] - Min time between consecutive request starts of requests that have been re-queued.
+   * @property {number} [requeueMaxRetry=3] - Msx number of atteempts to make for failed request.
+   * @property {array} [requeueCodes=[429,500,503]] - Array of http result codes that should be retried.
+   * @property {number} [requestTimeout=20000] - Timeout for an individual request recieving a response.
+   * @property {number} [queueSize=10000] - Size of the buffer that holds outbound requests.
+   * @property {number} [requeueSize=10000] - Size of the buffer that holds outbound re-queue requests.
+
+* Storage. There has been no testing of the `bot.store()`, `bot.recall()`, `bot.forget()` functions.   While they may work, it is reccomended that developers validate this before publishing a bot that leverages them.  We do plan to add some type of store functionality at a later data.
+
 ## Common migration tasks
 Alternatly, since elements of the bot and trigger objects have also changed, one might just bite the bullet, and do some search and replace.  The biggest migration tasks come from the renaming of flint to framework and the change in structures for the bot and trigger objects.  Common case sensitive search and replace tasks might include
 
@@ -78,10 +94,11 @@ For developer's who are porting existing flint based bots to this framework the 
 | active        | active       | Bot active state                             |                                                              |
 | person        | --           | Bot Person Object                            | Availabile as bot.framework.person                         |
 | email         | --           | Bot email                                    | Availabile as bot.framework.person.emails[0]                                   | 
-| team          | --           | Bot team object                              | available via bot.getTeam() convenience function TODO        |
+| team          | --           | Bot team object                              | This object is seldom used and creating it slows down spawning a bot.  Apps that want it can check if `bot.room.teamId` exists and if so call `bot.webex.teams.get(bot.room.teamId)`       |
 | room          | room         | Bot room object                              | Now is standard webex room object                            |
 | membership    | membership   | Bot membership object                        | Standard Webex Teams membership object for bot               |
-| memberships   | memberships  | All memberships for bot's space              | available via bot.getMemberships() convenience function TODO |
+| memberships   | memberships  | All memberships for bot's space              | This array is seldom used.  Creating it slows down the initial bot spawn, and keeping it "current" requires periodic "refresh" calls to the platform.  Apps that want to inspect room memberships can instead call `bot.webex.memberships.get({roomId: bot.room.id})` at the time the data is needed.  The response is a standard Webex response and the members will be in an array called `items`.
+|
 | isLocked      | isLocked     | If bot's space is locked                     |                                                              |
 | isModerator   | isModerator  | If bot is a moderator                        |                                                              |
 | isMonitor     | --           | If bot is a moderator                        |  isMonitor is deprecated                                     |

--- a/docs/migrate-from-node-flint.md
+++ b/docs/migrate-from-node-flint.md
@@ -44,7 +44,6 @@ Not all of the functionality in flint has been migrated to the new framework.  A
    * @property {number} [requeueMinTime=minTime*10] - Min time between consecutive request starts of requests that have been re-queued.
    * @property {number} [requeueMaxRetry=3] - Msx number of atteempts to make for failed request.
    * @property {array} [requeueCodes=[429,500,503]] - Array of http result codes that should be retried.
-   * @property {number} [requestTimeout=20000] - Timeout for an individual request recieving a response.
    * @property {number} [queueSize=10000] - Size of the buffer that holds outbound requests.
    * @property {number} [requeueSize=10000] - Size of the buffer that holds outbound re-queue requests.
 

--- a/lib/framework.js
+++ b/lib/framework.js
@@ -52,15 +52,6 @@ function Framework(options) {
    * @property {string} [webhookUrl] - URL that is used for Webex API to send callbacks.  If not set events are received via websocket
    * @property {string} [webhookSecret] - If specified, inbound webhooks are authorized before being processed. Ignored if webhookUrl is not set.
    * @property {string} [messageFormat=text] - Default Webex message format to use with bot.say().
-   * @property {number} [maxPageItems=50] - Max results that the paginator uses.
-   * @property {number} [maxConcurrent=3] - Max concurrent sessions to the Webex API
-   * @property {number} [minTime=600] - Min time between consecutive request starts.
-   * @property {number} [requeueMinTime=minTime*10] - Min time between consecutive request starts of requests that have been re-queued.
-   * @property {number} [requeueMaxRetry=3] - Msx number of atteempts to make for failed request.
-   * @property {array} [requeueCodes=[429,500,503]] - Array of http result codes that should be retried.
-   * @property {number} [requestTimeout=20000] - Timeout for an individual request recieving a response.
-   * @property {number} [queueSize=10000] - Size of the buffer that holds outbound requests.
-   * @property {number} [requeueSize=10000] - Size of the buffer that holds outbound re-queue requests.
    * @property {string} [id=random] - The id this instance of Framework uses.
    * @property {string} [webhookRequestJSONLocation=body] - The property under the Request to find the JSON contents.
    * @property {Boolean} [removeWebhooksOnStart=true] - If you wish to have the bot remove all account webhooks when starting. Ignored if webhookUrl is not set.
@@ -279,6 +270,12 @@ Framework.prototype.start = function () {
 
   // if not started...
   if (!this.active) {
+    // Check if any of the old, non-supported flint options are in place
+    let errMsg;
+    if (errMsg = optionsIncludeNonSupported(this.options)) {
+      return when.reject(new Error(errMsg));
+    }
+
 
     // init storage default storage driver if start is called before
     if (!this.storageActive) {
@@ -2307,4 +2304,41 @@ function cleanupListeners(framework) {
         return when(true);
       });
   }
+}
+
+function optionsIncludeNonSupported(options) {
+  if (typeof options != 'object') {
+    return 'Framework must be instantiated with an object that contains options';
+  }
+  if (!('token' in options)) {
+    return 'Framework options missing required attribute: token';
+  }
+  if ('maxPageItems' in options) {
+    return 'Framework instantiated with non supported option: maxPageItems';
+  }
+  if ('maxConcurrent' in options) {
+    return 'Framework instantiated with non supported option: maxConcurrent';
+  }
+  if ('minTime' in options) {
+    return 'Framework instantiated with non supported option: minTime';
+  }
+  if ('requeueMinTime' in options) {
+    return 'Framework instantiated with non supported option: requeueMinTime';
+  }
+  if ('requeueMaxRetry' in options) {
+    return 'Framework instantiated with non supported option: requeueMaxRetry';
+  }
+  if ('requeueCodes' in options) {
+    return 'Framework instantiated with non supported option: requeueCodes';
+  }
+  if ('requestTimeout' in options) {
+    return 'Framework instantiated with non supported option: requestTimeout';
+  }
+  if ('queueSize' in options) {
+    return 'Framework instantiated with non supported option: queueSize';
+  }
+  if ('requeueSize' in options) {
+    return 'Framework instantiated with non supported option: requeueSize';
+  }
+  return '';
 }

--- a/lib/framework.js
+++ b/lib/framework.js
@@ -2331,9 +2331,6 @@ function optionsIncludeNonSupported(options) {
   if ('requeueCodes' in options) {
     return 'Framework instantiated with non supported option: requeueCodes';
   }
-  if ('requestTimeout' in options) {
-    return 'Framework instantiated with non supported option: requestTimeout';
-  }
   if ('queueSize' in options) {
     return 'Framework instantiated with non supported option: queueSize';
   }

--- a/test/bot-tests.js
+++ b/test/bot-tests.js
@@ -6,6 +6,7 @@
 
 const Framework = require('../lib/framework');
 const Webex = require('webex');
+const assert = require('assert');
 console.log('Starting bot-tests...');
 
 // Initialize the framework and user objects once for all the tests
@@ -30,6 +31,57 @@ if ((typeof process.env.BOT_API_TOKEN === 'string') &&
 var common = require("./common/common");
 common.setFramework(framework);
 common.setUser(userWebex);
+
+// Validate that framwork.start() fails with invalid configs
+describe('#framework invalid config tests', () => {
+  let options = {};
+  let f = null;
+
+  it('fails with no token set', () => {
+    f = new Framework(options);
+    return f.start()
+      .then(() => {
+        return (Promise.reject(new Error('framework.start() should fail when no token is set')));
+      })
+      .catch((e) => {
+        assert(e.message === 'Framework options missing required attribute: token',
+          `Got unexpected error response: ${e.message}`);
+        return Promise.resolve(true);
+      });
+  });
+
+  it('fails when options.minTime is set', () => {
+    options.token = process.env.BOT_API_TOKEN;
+    options.minTime = 'something';
+    f = new Framework(options);
+    return f.start()
+      .then(() => {
+        return (Promise.reject(new Error('framework.start() should fail when options.minTime is set')));
+      })
+      .catch((e) => {
+        assert(e.message === 'Framework instantiated with non supported option: minTime',
+          `Got unexpected error response: ${e.message}`);
+        delete options.minTime;
+        return Promise.resolve(true);
+      });
+  });
+
+  it('fails when options.requeueSize is set', () => {
+    options.token = process.env.BOT_API_TOKEN;
+    options.requeueSize = 'something';
+    f = new Framework(options);
+    return f.start()
+      .then(() => {
+        return (Promise.reject(new Error('framework.start() should fail when options.requeueSize is set')));
+      })
+      .catch((e) => {
+        assert(e.message === 'Framework instantiated with non supported option: requeueSize',
+          `Got unexpected error response: ${e.message}`);
+        return Promise.resolve(true);
+      });
+  });
+
+});
 
 // Start up an instance of framework that we will use across multiple tests
 describe('#framework', () => {

--- a/test/common/common.js
+++ b/test/common/common.js
@@ -470,20 +470,20 @@ module.exports = {
       });
     },
 
-      activeBot.messageHandler = function (testName, eventsData, promiseResolveFunction) {
-        activeBot.once('message', (bot, trigger, id) => {
-          this.framework.debug(`Bot message event occurred in test ${testName}`);
-          assert(validator.isBot(bot),
-            'message event did not include a valid bot');
-          assert((bot.id === activeBot.id),
-            'bot returned in bot.on("message") is not the one expected');
-          assert(validator.isTrigger(trigger),
-            'message event did not include a valid trigger');
-          assert((id === activeBot.id),
-            'id returned in framework.on("message") is not the one expected');
-          promiseResolveFunction(true);
-        });
-      };
+    activeBot.messageHandler = function (testName, eventsData, promiseResolveFunction) {
+      activeBot.once('message', (bot, trigger, id) => {
+        this.framework.debug(`Bot message event occurred in test ${testName}`);
+        assert(validator.isBot(bot),
+          'message event did not include a valid bot');
+        assert((bot.id === activeBot.id),
+          'bot returned in bot.on("message") is not the one expected');
+        assert(validator.isTrigger(trigger),
+          'message event did not include a valid trigger');
+        assert((id === activeBot.id),
+          'id returned in framework.on("message") is not the one expected');
+        promiseResolveFunction(true);
+      });
+    };
 
     activeBot.filesHandler = function (testName, eventsData, promiseResolveFunction) {
       activeBot.once('files', (bot, trigger, id) => {


### PR DESCRIPTION
Document that the framework does not currently support retry capabilities for pagination or 429 responses. Fail initialization if user attempts to start framework with any of these parameters set.