### PR TITLE
Add tests

### DIFF
--- a/docs/migrate-from-node-flint.md
+++ b/docs/migrate-from-node-flint.md
@@ -38,7 +38,7 @@ Naming the new Framework object `flint`, allows existing `flint.hears()` and `fl
 Not all of the functionality in flint has been migrated to the new framework.  Apps that rely on any of the following may wish to postpone their migration (or look to implement these features some other way):
 
 * Retry logic for pagination and rate limiting.  The philosopy behind the framework is to encourage developers to leverage the Webex SDK (exposed as an element in the frameowrk and bot objects), natively when needed.   When appropriate applications should inspect the reponse headers for pagination and rate limiting (HTTP 429 Response Code) as needed.  `framework.start()` will fail when the framework was passed a config object that includes any of the following options:
-     * @property {number} [maxPageItems=50] - Max results that the paginator uses.
+   * @property {number} [maxPageItems=50] - Max results that the paginator uses.
    * @property {number} [maxConcurrent=3] - Max concurrent sessions to the Webex API
    * @property {number} [minTime=600] - Min time between consecutive request starts.
    * @property {number} [requeueMinTime=minTime*10] - Min time between consecutive request starts of requests that have been re-queued.
@@ -47,7 +47,7 @@ Not all of the functionality in flint has been migrated to the new framework.  A
    * @property {number} [queueSize=10000] - Size of the buffer that holds outbound requests.
    * @property {number} [requeueSize=10000] - Size of the buffer that holds outbound re-queue requests.
 
-* Storage. There has been no testing of the `bot.store()`, `bot.recall()`, `bot.forget()` functions.   While they may work, it is reccomended that developers validate this before publishing a bot that leverages them.  We do plan to add some type of store functionality at a later data.
+* Storage. There has been no testing of the redis version of the `bot.store()`, `bot.recall()`, `bot.forget()` functions.   While they may work, it is reccomended that developers validate this before publishing a bot that leverages redis.  
 
 ## Common migration tasks
 Alternatly, since elements of the bot and trigger objects have also changed, one might just bite the bullet, and do some search and replace.  The biggest migration tasks come from the renaming of flint to framework and the change in structures for the bot and trigger objects.  Common case sensitive search and replace tasks might include

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -31,6 +31,8 @@ The initial goal of the project was to support the basic framework initiation an
 - [x] Rename from flint to framework
 - [ ] Get rid fo flint pass through functions that are natively supported by the webex sdk
 - [x] Update contribution doc to explain how to run tests
+- [ ] Add retry logic for pagination
+- [ ] Add retry logic for 429s
 - [ ] Build a webex-node-integration-framework around this framework that demonstrates OAuth token management and creates a unique framework instance for each authorized user
 
 ## New functions
@@ -52,6 +54,7 @@ node-flint provides a storage system to allow developers to store and retrieve d
 ## Improving the tests
 
 - [ ] Add a ability to create a bot and user on the fly for the tests
+- [x] Add test case for attachmentAction events
 - [ ] Refactor the tests so the framework.isBotAccount variable is used to determine if mentions are needed in the user messages
 - [x] Break out the tests so they aren't in one monolithic file but don't create a new framework each time
 - [ ] Track and report the number of times each flint event was tested, to catch gaps in event validation

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -44,7 +44,7 @@ A goal of this project was to extend the framework to support new functionality 
 ## Storage
 node-flint provides a storage system to allow developers to store and retrieve data associated with individual bot/space combinations.   This framework has not modified that code, but has also not tested it to see if it has broken.
 
-- [ ] Add storage tests
+- [x] Add storage tests
 - [ ] Add mongo storage
 
 ## Migrating from node-flint

--- a/docs/version-history.md
+++ b/docs/version-history.md
@@ -1,3 +1,9 @@
+## v 0.5.0
+* Updated framework to webex sdk v1.80.80
+* Added support for attachmentAction events via webesocket.  (SDK added this in v1.80.79)
+* Updated migration document to explicitly state that the framework does not support retries for pagination or 429 errors.   framework.start() will fail now if the parameters around retry logic are set.  Hope to add this back, at least for pagination, which the webex SDK provides an interface for, in the future.
+* Added tests for bot.[store,recall,forget].   Only tested memory storage so far.  Migrating doc still warns that redis is untested.
+  
 ## v 0.4.0
 * Moved repo to https://github.com/webex/webex-node-bot-framework
 * Updated use of Buffer in lib/utils.js to avoid deprecation warning

--- a/lib/validator.js
+++ b/lib/validator.js
@@ -74,16 +74,17 @@ Validator.isBot = (bot) => {
  */
 Validator.isTrigger = (trigger) => {
   let result = (typeof trigger === 'object'
-    && (typeof trigger.args === 'object')
     && (typeof trigger.id === 'string')
     && (typeof trigger.person === 'object')
     && (typeof trigger.personId === 'string')
-    && (typeof trigger.text === 'string')
     && (typeof trigger.type === 'string')
   );
   if (result) {
     if (trigger.type === 'message') {
-      result = (typeof trigger.message === 'object');
+      result = (typeof trigger.message === 'object'
+        && (typeof trigger.args === 'object')
+        && (typeof trigger.text === 'string')
+      );
     } else if (trigger.type === 'attachmentAction') {
       result = (typeof trigger.attachmentAction === 'object');
     } else {

--- a/lib/websocket.js
+++ b/lib/websocket.js
@@ -32,14 +32,16 @@ function Websocket(framework, webhook) {
 
 Websocket.prototype.init = function() {
 
-  // register for message, membership and room events
-  // TODO Add attachmentActions when webex sdk supports it
-  let messagesPromise = this.framework.webex.messages.listen();
-  let membershipsPromise = this.framework.webex.memberships.listen();
-  let roomsPromise = this.framework.webex.rooms.listen();
+  // register for message, membership room and attachmentAction events
+  let listenerPromises = [];
+  listenerPromises.push(this.framework.webex.messages.listen());
+  listenerPromises.push(this.framework.webex.memberships.listen());
+  listenerPromises.push(this.framework.webex.rooms.listen());
+  listenerPromises.push(this.framework.webex.attachmentActions.listen());
 
-  return Promise.all([messagesPromise, membershipsPromise, roomsPromise])
+  return Promise.all(listenerPromises)
     .then(() => {
+      this.framework.webex.attachmentActions.on('created', (event) => processEvent(this.framework, event, this.name));
       this.framework.webex.messages.on('created', (event) => processEvent(this.framework, event, this.name));
       this.framework.webex.messages.on('deleted', (event) => processEvent(this.framework, event, this.name));
       this.framework.webex.memberships.on('created', (event) => processEvent(this.framework, event, this.name));

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,8 @@
     "@babel/parser": {
       "version": "7.7.5",
       "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.7.5.tgz",
-      "integrity": "sha512-KNlOe9+/nk4i29g0VXgl8PEXIRms5xKLJeuZ6UptN0fHv+jDiriG+y94X6qAgWTR0h3KaoM1wK5G5h7MHFRSig=="
+      "integrity": "sha512-KNlOe9+/nk4i29g0VXgl8PEXIRms5xKLJeuZ6UptN0fHv+jDiriG+y94X6qAgWTR0h3KaoM1wK5G5h7MHFRSig==",
+      "dev": true
     },
     "@textlint/ast-node-types": {
       "version": "4.2.5",
@@ -31,11 +32,11 @@
       }
     },
     "@webex/common": {
-      "version": "1.80.46",
-      "resolved": "https://registry.npmjs.org/@webex/common/-/common-1.80.46.tgz",
-      "integrity": "sha512-1yxk4bYRsE+NDjybrlUPT8oWJ2unAvWc4tO8ikS48Ts8MxIuPcSlwvzm4CYriSZbxHi2cGUAoMpR3keBZiK0og==",
+      "version": "1.80.80",
+      "resolved": "https://registry.npmjs.org/@webex/common/-/common-1.80.80.tgz",
+      "integrity": "sha512-GMQF2ed3gsCaE9ko5Xey1GsyOQdEFt4zQlUbHpppVlUoDBgZS0uUJjR3Xy9tm9UnpEzK05SstKpQe6w/xXa9CA==",
       "requires": {
-        "@webex/common": "1.80.46",
+        "@webex/common": "1.80.80",
         "babel-runtime": "^6.26.0",
         "backoff": "^2.5.0",
         "core-decorators": "^0.20.0",
@@ -45,17 +46,17 @@
       }
     },
     "@webex/common-timers": {
-      "version": "1.80.46",
-      "resolved": "https://registry.npmjs.org/@webex/common-timers/-/common-timers-1.80.46.tgz",
-      "integrity": "sha512-7ZLUUVVYFFcQnUXiwMQ+rRyxngeSx+olEluoO7uO8Saig9sNAA0dLhrxXqTj799U9e3WdFPDVqjd38VEdMtgbg==",
+      "version": "1.80.80",
+      "resolved": "https://registry.npmjs.org/@webex/common-timers/-/common-timers-1.80.80.tgz",
+      "integrity": "sha512-vlhiMlxDKGHsoaGFFzK6WhZUjMISrwydQUjBKLrTjlFfqXlvDw7i7AAnCllHASvugViMqX5xcTFlpbp1JqktnQ==",
       "requires": {
         "envify": "^4.1.0"
       }
     },
     "@webex/helper-html": {
-      "version": "1.80.46",
-      "resolved": "https://registry.npmjs.org/@webex/helper-html/-/helper-html-1.80.46.tgz",
-      "integrity": "sha512-/UPBYvErMjFYAw+Pwwp+zOZSSISTYMmrPK0fmoTAt2QMEKz26/bQT1JSTPL4eyvKpfaq8tdJbQ0c17tgyF78+A==",
+      "version": "1.80.80",
+      "resolved": "https://registry.npmjs.org/@webex/helper-html/-/helper-html-1.80.80.tgz",
+      "integrity": "sha512-4vOmbQG5I9YetZZAjzU3e2vEajOz+TBAt7Zku/O75w3IAOLgpFp3yU0K3NZozPKlWQ/aQjpu+bK+R+ZOLTRJbA==",
       "requires": {
         "babel-runtime": "^6.26.0",
         "envify": "^4.1.0",
@@ -63,11 +64,11 @@
       }
     },
     "@webex/helper-image": {
-      "version": "1.80.46",
-      "resolved": "https://registry.npmjs.org/@webex/helper-image/-/helper-image-1.80.46.tgz",
-      "integrity": "sha512-oodRzz9yue8cOqyqnSJp4qvV50JRVID694Ksl6Kw0N3PTfPfKkq6GCSEudLBAjRwafqUu6tJh6IsGLJj0PKihw==",
+      "version": "1.80.80",
+      "resolved": "https://registry.npmjs.org/@webex/helper-image/-/helper-image-1.80.80.tgz",
+      "integrity": "sha512-NWnlMKTpfVY/sxbXJBPo8AWfhcTv/HnCH33wlPWQPYXep9YsRYjjXO4p0LrROUbaWyotU8tJ04IJCrxM8AIUVg==",
       "requires": {
-        "@webex/http-core": "1.80.46",
+        "@webex/http-core": "1.80.80",
         "babel-runtime": "^6.26.0",
         "envify": "^4.1.0",
         "exif": "^0.6.0",
@@ -77,11 +78,11 @@
       }
     },
     "@webex/http-core": {
-      "version": "1.80.46",
-      "resolved": "https://registry.npmjs.org/@webex/http-core/-/http-core-1.80.46.tgz",
-      "integrity": "sha512-IaQ+JNUg58up8+qbpV2LylZuJEPrCjhORVZqLq2teVp+hjPfAnT75/H4uq/J+L+Aso9/E348iXppveFlC8LTew==",
+      "version": "1.80.80",
+      "resolved": "https://registry.npmjs.org/@webex/http-core/-/http-core-1.80.80.tgz",
+      "integrity": "sha512-z/DtOvTFkdSTxVe5er4YKyXZ+JPx1pgKY27PT3v/SHot2C0XlHE/iuCMM6GRmSp3P11EEDTculDe7y87e4mCvg==",
       "requires": {
-        "@webex/common": "1.80.46",
+        "@webex/common": "1.80.80",
         "babel-runtime": "^6.26.0",
         "envify": "^4.1.0",
         "file-type": "^3.9.0",
@@ -95,47 +96,49 @@
       }
     },
     "@webex/internal-plugin-calendar": {
-      "version": "1.80.46",
-      "resolved": "https://registry.npmjs.org/@webex/internal-plugin-calendar/-/internal-plugin-calendar-1.80.46.tgz",
-      "integrity": "sha512-6571BVC4b/1vumvx/W1V3L+spv930NuaZcAnb32F94EpEz6j6c49QXRLJ0EtawPOBG2uZ6cxlhO7Ao6wgeBzrQ==",
+      "version": "1.80.80",
+      "resolved": "https://registry.npmjs.org/@webex/internal-plugin-calendar/-/internal-plugin-calendar-1.80.80.tgz",
+      "integrity": "sha512-j+L8H+8i0o2Y1heoOWTmp9Hj2GhX9ZLZMszCwfAM5G9ZcXgZDiEZPtAyzXMrknrnim29n1NS8TewsXrfXV3UIg==",
       "requires": {
-        "@webex/internal-plugin-conversation": "1.80.46",
-        "@webex/internal-plugin-encryption": "1.80.46",
-        "@webex/internal-plugin-wdm": "1.80.46",
-        "@webex/webex-core": "1.80.46",
+        "@webex/internal-plugin-conversation": "1.80.80",
+        "@webex/internal-plugin-encryption": "1.80.80",
+        "@webex/internal-plugin-wdm": "1.80.80",
+        "@webex/webex-core": "1.80.80",
         "babel-runtime": "^6.26.0",
         "envify": "^4.1.0",
         "lodash": "^4.17.15"
       }
     },
     "@webex/internal-plugin-conversation": {
-      "version": "1.80.46",
-      "resolved": "https://registry.npmjs.org/@webex/internal-plugin-conversation/-/internal-plugin-conversation-1.80.46.tgz",
-      "integrity": "sha512-f5xpURBb32pej8GqrOWPHUt+CbEHjz4Cp3GUNJ8+1fp4WBwL+teVXLjVHbM2ft6M/HiZ6BXpFHG3HsSkLcuN7A==",
+      "version": "1.80.80",
+      "resolved": "https://registry.npmjs.org/@webex/internal-plugin-conversation/-/internal-plugin-conversation-1.80.80.tgz",
+      "integrity": "sha512-ehjWE48+0bxY1Gny0drjcOGBrx09zvxXrCo4rjV400sh3BUCq5+1ZWFpbHQNNhxUvJbfN85wnwr07ghHl9RkCg==",
       "requires": {
-        "@webex/common": "1.80.46",
-        "@webex/helper-html": "1.80.46",
-        "@webex/helper-image": "1.80.46",
-        "@webex/internal-plugin-encryption": "1.80.46",
-        "@webex/internal-plugin-user": "1.80.46",
-        "@webex/webex-core": "1.80.46",
+        "@webex/common": "1.80.80",
+        "@webex/helper-html": "1.80.80",
+        "@webex/helper-image": "1.80.80",
+        "@webex/internal-plugin-encryption": "1.80.80",
+        "@webex/internal-plugin-user": "1.80.80",
+        "@webex/webex-core": "1.80.80",
         "babel-runtime": "^6.26.0",
+        "crypto-js": "^3.1.9-1",
         "envify": "^4.1.0",
         "lodash": "^4.17.15",
+        "node-scr": "^0.2.2",
         "uuid": "^3.3.2"
       }
     },
     "@webex/internal-plugin-encryption": {
-      "version": "1.80.46",
-      "resolved": "https://registry.npmjs.org/@webex/internal-plugin-encryption/-/internal-plugin-encryption-1.80.46.tgz",
-      "integrity": "sha512-NhHY/GL9xpji6YHhixHeMLqV8C887Quv+YKifiJxWl9OUQv2g66ItYRqZteE1Cljzb7JItB8fe2iVSWzRWdypg==",
+      "version": "1.80.80",
+      "resolved": "https://registry.npmjs.org/@webex/internal-plugin-encryption/-/internal-plugin-encryption-1.80.80.tgz",
+      "integrity": "sha512-FgmpP1KOzw//1Yho6lli6xt+0Dy0guIKcPQ1rXkemoddbWX1tKap/2mIcGlPKX+S5lAtq4vXTe8orI2zzjD3nA==",
       "requires": {
-        "@webex/common": "1.80.46",
-        "@webex/common-timers": "1.80.46",
-        "@webex/http-core": "1.80.46",
-        "@webex/internal-plugin-mercury": "1.80.46",
-        "@webex/internal-plugin-wdm": "1.80.46",
-        "@webex/webex-core": "1.80.46",
+        "@webex/common": "1.80.80",
+        "@webex/common-timers": "1.80.80",
+        "@webex/http-core": "1.80.80",
+        "@webex/internal-plugin-mercury": "1.80.80",
+        "@webex/internal-plugin-wdm": "1.80.80",
+        "@webex/webex-core": "1.80.80",
         "babel-runtime": "^6.26.0",
         "debug": "^3.2.6",
         "envify": "^4.1.0",
@@ -161,44 +164,44 @@
       }
     },
     "@webex/internal-plugin-feature": {
-      "version": "1.80.46",
-      "resolved": "https://registry.npmjs.org/@webex/internal-plugin-feature/-/internal-plugin-feature-1.80.46.tgz",
-      "integrity": "sha512-93Jk1NXMFROO5TCi719gWFjyisjopQHfeQH8v2lf0CkUjLV5iJfA5bZg1HDZJuwXKOalR2jw9qVPYzxZ1qEWvQ==",
+      "version": "1.80.80",
+      "resolved": "https://registry.npmjs.org/@webex/internal-plugin-feature/-/internal-plugin-feature-1.80.80.tgz",
+      "integrity": "sha512-9nKULagJICSMFsw5UCfphq8LzA3+MsRoHc5Rzw9sfkWjOkJPaGLdg3j/dPpfs75xS0f3jE/QOa4w+7W3xgHCUQ==",
       "requires": {
-        "@webex/internal-plugin-mercury": "1.80.46",
-        "@webex/internal-plugin-wdm": "1.80.46",
-        "@webex/webex-core": "1.80.46",
+        "@webex/internal-plugin-mercury": "1.80.80",
+        "@webex/internal-plugin-wdm": "1.80.80",
+        "@webex/webex-core": "1.80.80",
         "babel-runtime": "^6.26.0",
         "envify": "^4.1.0",
         "lodash": "^4.17.15"
       }
     },
     "@webex/internal-plugin-lyra": {
-      "version": "1.80.46",
-      "resolved": "https://registry.npmjs.org/@webex/internal-plugin-lyra/-/internal-plugin-lyra-1.80.46.tgz",
-      "integrity": "sha512-lNZPYxMmI8Ey96EDd9+9suw+UlsFv8Yl7A7s3m1dCe8KVmYrhVqHHr7AhfMJa/q/2B5hSzZv9MGcNT9T5fJ61w==",
+      "version": "1.80.80",
+      "resolved": "https://registry.npmjs.org/@webex/internal-plugin-lyra/-/internal-plugin-lyra-1.80.80.tgz",
+      "integrity": "sha512-k/fRzuGh/2ibRMZgCkFxwnKUqjna/URdU8DnRrVV2hAsCDLxv9mlKySWpBpvt2q2KIMPxEvNw/UYEMr7DDUMoA==",
       "requires": {
-        "@webex/common": "1.80.46",
-        "@webex/internal-plugin-conversation": "1.80.46",
-        "@webex/internal-plugin-encryption": "1.80.46",
-        "@webex/internal-plugin-feature": "1.80.46",
-        "@webex/internal-plugin-mercury": "1.80.46",
-        "@webex/webex-core": "1.80.46",
+        "@webex/common": "1.80.80",
+        "@webex/internal-plugin-conversation": "1.80.80",
+        "@webex/internal-plugin-encryption": "1.80.80",
+        "@webex/internal-plugin-feature": "1.80.80",
+        "@webex/internal-plugin-mercury": "1.80.80",
+        "@webex/webex-core": "1.80.80",
         "babel-runtime": "^6.26.0",
         "envify": "^4.1.0"
       }
     },
     "@webex/internal-plugin-mercury": {
-      "version": "1.80.46",
-      "resolved": "https://registry.npmjs.org/@webex/internal-plugin-mercury/-/internal-plugin-mercury-1.80.46.tgz",
-      "integrity": "sha512-Y+Qlmi8ajSvMJ4Q4HT7Ny5JM8CeSEQ9EZuHRiTR63U5fsrz848QAkHYxq7Fp7fmZBLQNgZmetA0kiPdZ5gH50Q==",
+      "version": "1.80.80",
+      "resolved": "https://registry.npmjs.org/@webex/internal-plugin-mercury/-/internal-plugin-mercury-1.80.80.tgz",
+      "integrity": "sha512-/9T19vjo4MCkqeJOgKdmg075xBlcWjSlG351Aq7SXB7EFfyR/fmoulfGsGBOyHPh6hFaDkb8J5JGiU/3vr3Pzg==",
       "requires": {
-        "@webex/common": "1.80.46",
-        "@webex/common-timers": "1.80.46",
-        "@webex/internal-plugin-feature": "1.80.46",
-        "@webex/internal-plugin-metrics": "1.80.46",
-        "@webex/internal-plugin-wdm": "1.80.46",
-        "@webex/webex-core": "1.80.46",
+        "@webex/common": "1.80.80",
+        "@webex/common-timers": "1.80.80",
+        "@webex/internal-plugin-feature": "1.80.80",
+        "@webex/internal-plugin-metrics": "1.80.80",
+        "@webex/internal-plugin-wdm": "1.80.80",
+        "@webex/webex-core": "1.80.80",
         "babel-runtime": "^6.26.0",
         "backoff": "^2.5.0",
         "envify": "^4.1.0",
@@ -208,65 +211,65 @@
       }
     },
     "@webex/internal-plugin-metrics": {
-      "version": "1.80.46",
-      "resolved": "https://registry.npmjs.org/@webex/internal-plugin-metrics/-/internal-plugin-metrics-1.80.46.tgz",
-      "integrity": "sha512-ijFDWaTzzo1y6koznNNnwI/c5KiwR7NBMWH5LpTQd4/u/pkDE/ig6PQ/dpOj25sEJG/j9ljyfmIqB51LQig3Nw==",
+      "version": "1.80.80",
+      "resolved": "https://registry.npmjs.org/@webex/internal-plugin-metrics/-/internal-plugin-metrics-1.80.80.tgz",
+      "integrity": "sha512-6Lfq7NMihlkgL82L73p9aJwGl1/FyM6v43nQy1Rw50fNk9EK8KXrRO1NL+9mRTgu48bVw7q183A8kZ0Y0khCNA==",
       "requires": {
-        "@webex/common": "1.80.46",
-        "@webex/common-timers": "1.80.46",
-        "@webex/internal-plugin-wdm": "1.80.46",
-        "@webex/webex-core": "1.80.46",
+        "@webex/common": "1.80.80",
+        "@webex/common-timers": "1.80.80",
+        "@webex/internal-plugin-wdm": "1.80.80",
+        "@webex/webex-core": "1.80.80",
         "babel-runtime": "^6.26.0",
         "envify": "^4.1.0"
       }
     },
     "@webex/internal-plugin-presence": {
-      "version": "1.80.46",
-      "resolved": "https://registry.npmjs.org/@webex/internal-plugin-presence/-/internal-plugin-presence-1.80.46.tgz",
-      "integrity": "sha512-wNxM57GOu94sMCrix4BaGXoX2z90FFM7IB0uRnaypkN3PoOqEm1SiLSabya7SjcGjxIcuxPzObyQFsDiHoHE2Q==",
+      "version": "1.80.80",
+      "resolved": "https://registry.npmjs.org/@webex/internal-plugin-presence/-/internal-plugin-presence-1.80.80.tgz",
+      "integrity": "sha512-HKTtjaPqqF86wy9ARwLb40qATCd/2XqK8QbFBqyd7l7PDATKcVKqkzkF36qcLNhscP+AabgX1n7UoD/PQGMzxg==",
       "requires": {
-        "@webex/internal-plugin-wdm": "1.80.46",
-        "@webex/webex-core": "1.80.46",
+        "@webex/internal-plugin-wdm": "1.80.80",
+        "@webex/webex-core": "1.80.80",
         "babel-runtime": "^6.26.0",
         "envify": "^4.1.0",
         "lodash": "^4.17.15"
       }
     },
     "@webex/internal-plugin-search": {
-      "version": "1.80.46",
-      "resolved": "https://registry.npmjs.org/@webex/internal-plugin-search/-/internal-plugin-search-1.80.46.tgz",
-      "integrity": "sha512-u454C0NP+7GrJdD7PAA7Mf84KJHiTIlRV0rxl2Y77X1HSTkAuRNikfaSqyIRydh68M73NNzDatYIR61+TrlMEQ==",
+      "version": "1.80.80",
+      "resolved": "https://registry.npmjs.org/@webex/internal-plugin-search/-/internal-plugin-search-1.80.80.tgz",
+      "integrity": "sha512-F2HSmxLpBXE2Oa5ilhL4F/D93IXEfwq0ompynb2mParI2GDBWBtwCzNJylnQRThESxAhnXQPECEB7qtnBcv+wA==",
       "requires": {
-        "@webex/common": "1.80.46",
-        "@webex/internal-plugin-encryption": "1.80.46",
-        "@webex/webex-core": "1.80.46",
+        "@webex/common": "1.80.80",
+        "@webex/internal-plugin-encryption": "1.80.80",
+        "@webex/webex-core": "1.80.80",
         "babel-runtime": "^6.26.0",
         "envify": "^4.1.0",
         "lodash": "^4.17.15"
       }
     },
     "@webex/internal-plugin-user": {
-      "version": "1.80.46",
-      "resolved": "https://registry.npmjs.org/@webex/internal-plugin-user/-/internal-plugin-user-1.80.46.tgz",
-      "integrity": "sha512-IEJ9ZxSHKVOdPPz2qPYQloVBtBF9YzkCU0ZVhJchiS0d796yLsRK9q4pXI1Rh8c2kuzIudwEdESO6uCkjRoQEA==",
+      "version": "1.80.80",
+      "resolved": "https://registry.npmjs.org/@webex/internal-plugin-user/-/internal-plugin-user-1.80.80.tgz",
+      "integrity": "sha512-03yyX7m9a4XtMZqyVdi6O6IiwKWNRpz5w4HkYdn6yIw/PpUimd4/g99mNfUU/yH9iC2skjgJG/qeuFr2SoHqVA==",
       "requires": {
-        "@webex/common": "1.80.46",
-        "@webex/internal-plugin-wdm": "1.80.46",
-        "@webex/webex-core": "1.80.46",
+        "@webex/common": "1.80.80",
+        "@webex/internal-plugin-wdm": "1.80.80",
+        "@webex/webex-core": "1.80.80",
         "babel-runtime": "^6.26.0",
         "envify": "^4.1.0",
         "lodash": "^4.17.15"
       }
     },
     "@webex/internal-plugin-wdm": {
-      "version": "1.80.46",
-      "resolved": "https://registry.npmjs.org/@webex/internal-plugin-wdm/-/internal-plugin-wdm-1.80.46.tgz",
-      "integrity": "sha512-XEzrthD4G/KQlr6MiANpqfUh4qIIb3iLFwWoM1FFN/zMpQlf9+pPJqjrSaAoGMZz4TnRfz22dfX8jUGE+Tmy/A==",
+      "version": "1.80.80",
+      "resolved": "https://registry.npmjs.org/@webex/internal-plugin-wdm/-/internal-plugin-wdm-1.80.80.tgz",
+      "integrity": "sha512-iWG/uNBxUJ6cEVHWDLZSVHkh7APt1PW91WU5+jM/Lu2qk4qFQQf8S9QfEkdHoBcFJSzcSVNNMyi+ZndGfTWDHA==",
       "requires": {
-        "@webex/common": "1.80.46",
-        "@webex/common-timers": "1.80.46",
-        "@webex/http-core": "1.80.46",
-        "@webex/webex-core": "1.80.46",
+        "@webex/common": "1.80.80",
+        "@webex/common-timers": "1.80.80",
+        "@webex/http-core": "1.80.80",
+        "@webex/webex-core": "1.80.80",
         "ampersand-collection": "^2.0.2",
         "ampersand-state": "^5.0.3",
         "babel-runtime": "^6.26.0",
@@ -275,35 +278,53 @@
       }
     },
     "@webex/plugin-attachment-actions": {
-      "version": "1.80.46",
-      "resolved": "https://registry.npmjs.org/@webex/plugin-attachment-actions/-/plugin-attachment-actions-1.80.46.tgz",
-      "integrity": "sha512-Q5A9g0u2RJ5VeZOicbC8DhKGb8oAhoIxbOAkVDe5UaBNWfrT6Gr+H4ggHCCRLip3S5/Jutj6VGUPCvD3yspKaQ==",
+      "version": "1.80.80",
+      "resolved": "https://registry.npmjs.org/@webex/plugin-attachment-actions/-/plugin-attachment-actions-1.80.80.tgz",
+      "integrity": "sha512-1+AjCeIEdVc/XbTu509KtP1BagpOH7NeFHACNNjLxBrpfZm8he7m2vySVB2aAjDsF+rcKv/Ek8vuLVlQAP9oIw==",
       "requires": {
-        "@webex/internal-plugin-conversation": "1.80.46",
-        "@webex/internal-plugin-mercury": "1.80.46",
-        "@webex/webex-core": "1.80.46",
+        "@webex/common": "1.80.80",
+        "@webex/internal-plugin-conversation": "1.80.80",
+        "@webex/internal-plugin-mercury": "1.80.80",
+        "@webex/webex-core": "1.80.80",
         "babel-runtime": "^6.26.0",
-        "envify": "^4.1.0"
+        "debug": "^3.2.6",
+        "envify": "^4.1.0",
+        "lodash": "^4.17.15"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.2.6",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        }
       }
     },
     "@webex/plugin-authorization": {
-      "version": "1.80.46",
-      "resolved": "https://registry.npmjs.org/@webex/plugin-authorization/-/plugin-authorization-1.80.46.tgz",
-      "integrity": "sha512-iyHR0Hol8QMTr/Q1SZk29SQhN5rmKUn0OOpOwNY8otnxmq0hknyX/Dd7ro8RtAzRkTvOx7I68gN1M4nelROFzQ==",
+      "version": "1.80.80",
+      "resolved": "https://registry.npmjs.org/@webex/plugin-authorization/-/plugin-authorization-1.80.80.tgz",
+      "integrity": "sha512-iwpwSCh7PseLqVoDI4gLOLlvNj5nz9XalKYuh/7VycX4hruVplyxn6Q3fonkzbJoXELExobKDy6FpSDbOQu8oQ==",
       "requires": {
-        "@webex/plugin-authorization-browser": "1.80.46",
-        "@webex/plugin-authorization-node": "1.80.46",
+        "@webex/plugin-authorization-browser": "1.80.80",
+        "@webex/plugin-authorization-node": "1.80.80",
         "envify": "^4.1.0"
       }
     },
     "@webex/plugin-authorization-browser": {
-      "version": "1.80.46",
-      "resolved": "https://registry.npmjs.org/@webex/plugin-authorization-browser/-/plugin-authorization-browser-1.80.46.tgz",
-      "integrity": "sha512-6eTUhJlGLO69ZlITV3PoEhGEE77yIKg1v7wW0i8ZwUdEEviPVYBl9uKLOv3yyvSIhyCi54ruDbhVR/HtUpsyng==",
+      "version": "1.80.80",
+      "resolved": "https://registry.npmjs.org/@webex/plugin-authorization-browser/-/plugin-authorization-browser-1.80.80.tgz",
+      "integrity": "sha512-b0sTK5LcabLv9BhfLb+vmIvAfdsZo6ZxtHByV13SgfusTmUKU+UwOFLk6AtmGs1LXNnT82CzB+2cAwK2sNWfQA==",
       "requires": {
-        "@webex/common": "1.80.46",
-        "@webex/internal-plugin-wdm": "1.80.46",
-        "@webex/webex-core": "1.80.46",
+        "@webex/common": "1.80.80",
+        "@webex/internal-plugin-wdm": "1.80.80",
+        "@webex/webex-core": "1.80.80",
         "babel-runtime": "^6.26.0",
         "envify": "^4.1.0",
         "lodash": "^4.17.15",
@@ -311,26 +332,26 @@
       }
     },
     "@webex/plugin-authorization-node": {
-      "version": "1.80.46",
-      "resolved": "https://registry.npmjs.org/@webex/plugin-authorization-node/-/plugin-authorization-node-1.80.46.tgz",
-      "integrity": "sha512-x7oTUBHM6SV+udeg4GKWck2KaWl/1QZiPYaGsGgJyPfepsUU//ONk1ZD6rNlt+uqYTHw5EDys1si9LEta5VolA==",
+      "version": "1.80.80",
+      "resolved": "https://registry.npmjs.org/@webex/plugin-authorization-node/-/plugin-authorization-node-1.80.80.tgz",
+      "integrity": "sha512-Z1I5iY7hUhD+AYnlMPrNjuHxDwxiD4JYR+DOhpq+Vc2Mc5kSdjflUUi4Xpctvazr3YlFc+7XJqAL0rHxay+EbQ==",
       "requires": {
-        "@webex/common": "1.80.46",
-        "@webex/internal-plugin-wdm": "1.80.46",
-        "@webex/webex-core": "1.80.46",
+        "@webex/common": "1.80.80",
+        "@webex/internal-plugin-wdm": "1.80.80",
+        "@webex/webex-core": "1.80.80",
         "babel-runtime": "^6.26.0",
         "envify": "^4.1.0"
       }
     },
     "@webex/plugin-device-manager": {
-      "version": "1.80.46",
-      "resolved": "https://registry.npmjs.org/@webex/plugin-device-manager/-/plugin-device-manager-1.80.46.tgz",
-      "integrity": "sha512-puCiffBL9XD1MYsbIUmgUsoFjPsnyCU3VvqBmsuxYSaTvl2URkayUgQ+nCO89QJZieB0hG6gNNBrgIEc0hQ7+g==",
+      "version": "1.80.80",
+      "resolved": "https://registry.npmjs.org/@webex/plugin-device-manager/-/plugin-device-manager-1.80.80.tgz",
+      "integrity": "sha512-z7kLTMi1utnApjUxGmkXvvT6Vxqz2Ftx6OwqmHNPbIWk+HRfboufPe6PW+6QbSg4p5I17XP4l8Pl3kbGMWAPYg==",
       "requires": {
-        "@webex/internal-plugin-lyra": "1.80.46",
-        "@webex/internal-plugin-search": "1.80.46",
-        "@webex/internal-plugin-wdm": "1.80.46",
-        "@webex/webex-core": "1.80.46",
+        "@webex/internal-plugin-lyra": "1.80.80",
+        "@webex/internal-plugin-search": "1.80.80",
+        "@webex/internal-plugin-wdm": "1.80.80",
+        "@webex/webex-core": "1.80.80",
         "babel-runtime": "^6.26.0",
         "envify": "^4.1.0",
         "lodash": "^4.17.15",
@@ -338,26 +359,26 @@
       }
     },
     "@webex/plugin-logger": {
-      "version": "1.80.46",
-      "resolved": "https://registry.npmjs.org/@webex/plugin-logger/-/plugin-logger-1.80.46.tgz",
-      "integrity": "sha512-ZGJ/KgzQNQh5XFFwyV/6JM0up5fENreFpZ/tefLptiaO3rpL8lfxoA0UR6KDpAewTWqnjqY09XqkJ1bTv7jNvw==",
+      "version": "1.80.80",
+      "resolved": "https://registry.npmjs.org/@webex/plugin-logger/-/plugin-logger-1.80.80.tgz",
+      "integrity": "sha512-3haSLwB3y0SXm6cBG3i3Z3lQsU+h28KfXmSz7AK/kIT8r/72rJQSa2/I6ZzzyWma1PbNrI15kY2r1Rh5NXIcbw==",
       "requires": {
-        "@webex/common": "1.80.46",
-        "@webex/webex-core": "1.80.46",
+        "@webex/common": "1.80.80",
+        "@webex/webex-core": "1.80.80",
         "babel-runtime": "^6.26.0",
         "envify": "^4.1.0",
         "lodash": "^4.17.15"
       }
     },
     "@webex/plugin-meetings": {
-      "version": "1.80.46",
-      "resolved": "https://registry.npmjs.org/@webex/plugin-meetings/-/plugin-meetings-1.80.46.tgz",
-      "integrity": "sha512-M9tBGFsv9DHxaKnL6rDGchu+HAfvQgO+k7rHQXEjIBz5fqcoJ/fc+dU87L87vkYumKZlDIlCx4WvK/t357J+Kw==",
+      "version": "1.80.80",
+      "resolved": "https://registry.npmjs.org/@webex/plugin-meetings/-/plugin-meetings-1.80.80.tgz",
+      "integrity": "sha512-Zshs7sJxdUsFwoiJ9Zs3WlZydyl3zitvde2LGCWQIouWP6Gx+vDnM7Uz4zH25W0lku1qIO1vqAP0hQy6OB7pzA==",
       "requires": {
-        "@webex/common": "1.80.46",
-        "@webex/common-timers": "1.80.46",
-        "@webex/internal-plugin-mercury": "1.80.46",
-        "@webex/webex-core": "1.80.46",
+        "@webex/common": "1.80.80",
+        "@webex/common-timers": "1.80.80",
+        "@webex/internal-plugin-mercury": "1.80.80",
+        "@webex/webex-core": "1.80.80",
         "babel-runtime": "^6.26.0",
         "bowser": "1.9.4",
         "btoa": "^1.2.1",
@@ -370,14 +391,14 @@
       }
     },
     "@webex/plugin-memberships": {
-      "version": "1.80.46",
-      "resolved": "https://registry.npmjs.org/@webex/plugin-memberships/-/plugin-memberships-1.80.46.tgz",
-      "integrity": "sha512-YKwDFbLqyuuI2XCY9MTDNvjLeM6HugtG48l+QehHmy3sRneeazUYgBu6JLI1IzYubLxanQijrqDeGJDwnGQESA==",
+      "version": "1.80.80",
+      "resolved": "https://registry.npmjs.org/@webex/plugin-memberships/-/plugin-memberships-1.80.80.tgz",
+      "integrity": "sha512-7IqGXuLyOADxgv2ePVCsaqPc3fppqQtsAsjpvZuVEBE6eKjcj6ks8kAJfE55+YOhH45OmOo1z74NYTobECmyzg==",
       "requires": {
-        "@webex/common": "1.80.46",
-        "@webex/internal-plugin-conversation": "1.80.46",
-        "@webex/internal-plugin-mercury": "1.80.46",
-        "@webex/webex-core": "1.80.46",
+        "@webex/common": "1.80.80",
+        "@webex/internal-plugin-conversation": "1.80.80",
+        "@webex/internal-plugin-mercury": "1.80.80",
+        "@webex/webex-core": "1.80.80",
         "babel-runtime": "^6.26.0",
         "debug": "^3.2.6",
         "envify": "^4.1.0",
@@ -400,14 +421,14 @@
       }
     },
     "@webex/plugin-messages": {
-      "version": "1.80.46",
-      "resolved": "https://registry.npmjs.org/@webex/plugin-messages/-/plugin-messages-1.80.46.tgz",
-      "integrity": "sha512-jkbTQGoh8V2rDbpEFyQpEW2ojgeFHJWZkg4/6usoYpjaQem6YYptApv73CwiyNm7XCalyTRqY7ptZa5C6GJGkg==",
+      "version": "1.80.80",
+      "resolved": "https://registry.npmjs.org/@webex/plugin-messages/-/plugin-messages-1.80.80.tgz",
+      "integrity": "sha512-dNg9HM6G9Cl9/ZVwrmezv1uI2BfJz+3xEjNxCv8Ev7bUQeZXVakTbRvNG4V+WQeTxGjzTFbrzArGxyqwytkqMw==",
       "requires": {
-        "@webex/common": "1.80.46",
-        "@webex/internal-plugin-conversation": "1.80.46",
-        "@webex/internal-plugin-mercury": "1.80.46",
-        "@webex/webex-core": "1.80.46",
+        "@webex/common": "1.80.80",
+        "@webex/internal-plugin-conversation": "1.80.80",
+        "@webex/internal-plugin-mercury": "1.80.80",
+        "@webex/webex-core": "1.80.80",
         "babel-runtime": "^6.26.0",
         "debug": "^3.2.6",
         "envify": "^4.1.0",
@@ -430,25 +451,25 @@
       }
     },
     "@webex/plugin-people": {
-      "version": "1.80.46",
-      "resolved": "https://registry.npmjs.org/@webex/plugin-people/-/plugin-people-1.80.46.tgz",
-      "integrity": "sha512-yCE9ceb4lSvIDShAnUV390iMeNX6ZzCwEmq29xkEDEv11uzNplLhByg2WXJfd88rzBqBmFZwcw6jxEbjJhwy4Q==",
+      "version": "1.80.80",
+      "resolved": "https://registry.npmjs.org/@webex/plugin-people/-/plugin-people-1.80.80.tgz",
+      "integrity": "sha512-2uJ79RIOm6eKro60b80Swo0TwPLaoYKL0DymTpXnD+xSlxki1FXk8hDAs9/ESa9QKsWdlksjOYc6XY5oq5yGHw==",
       "requires": {
-        "@webex/common": "1.80.46",
-        "@webex/webex-core": "1.80.46",
+        "@webex/common": "1.80.80",
+        "@webex/webex-core": "1.80.80",
         "babel-runtime": "^6.26.0",
         "envify": "^4.1.0"
       }
     },
     "@webex/plugin-rooms": {
-      "version": "1.80.46",
-      "resolved": "https://registry.npmjs.org/@webex/plugin-rooms/-/plugin-rooms-1.80.46.tgz",
-      "integrity": "sha512-/vS+6WB6ocJiBckZPYP/c4r9N5e4ybokTCIdtQSYmPOCV/iZJHKAg/vHlLSCg1/TJvghMhbYeK+ywph5VU6jhQ==",
+      "version": "1.80.80",
+      "resolved": "https://registry.npmjs.org/@webex/plugin-rooms/-/plugin-rooms-1.80.80.tgz",
+      "integrity": "sha512-05LuYuUEgfWCMUFMV1lvqr5vnH3dbKh3xsnUs/2ffMauUjGRJQVuuPoN/NZdCldWs0vt5gVWKllqsuWBZfsyaQ==",
       "requires": {
-        "@webex/common": "1.80.46",
-        "@webex/internal-plugin-conversation": "1.80.46",
-        "@webex/internal-plugin-mercury": "1.80.46",
-        "@webex/webex-core": "1.80.46",
+        "@webex/common": "1.80.80",
+        "@webex/internal-plugin-conversation": "1.80.80",
+        "@webex/internal-plugin-mercury": "1.80.80",
+        "@webex/webex-core": "1.80.80",
         "babel-runtime": "^6.26.0",
         "debug": "^3.2.6",
         "envify": "^4.1.0",
@@ -471,51 +492,51 @@
       }
     },
     "@webex/plugin-team-memberships": {
-      "version": "1.80.46",
-      "resolved": "https://registry.npmjs.org/@webex/plugin-team-memberships/-/plugin-team-memberships-1.80.46.tgz",
-      "integrity": "sha512-DCP2KzXa0MJYDmEmxsQ+k1y96tJaFKz3itNs8ZohUIwXLk7K8XhnknGjQ/fWv4xacsRzAeBbNvm3S9gO7oJNVg==",
+      "version": "1.80.80",
+      "resolved": "https://registry.npmjs.org/@webex/plugin-team-memberships/-/plugin-team-memberships-1.80.80.tgz",
+      "integrity": "sha512-F5MymzTEZ3ptzglWb/iDSyNUwJ8y2xAlVeCWci8NfAcbCudGHyGCrTMdeH/5UX04gyh21B7c/dJiS6AuQQCoOw==",
       "requires": {
-        "@webex/webex-core": "1.80.46",
+        "@webex/webex-core": "1.80.80",
         "envify": "^4.1.0"
       }
     },
     "@webex/plugin-teams": {
-      "version": "1.80.46",
-      "resolved": "https://registry.npmjs.org/@webex/plugin-teams/-/plugin-teams-1.80.46.tgz",
-      "integrity": "sha512-nLumrH6oROtEImOUh7leywNJ92Gl6rdPHnxyp5M3ClhYVV3xy/eFO6RI3Npyf+Py3tactGwGclhMOkJ/8oLTtw==",
+      "version": "1.80.80",
+      "resolved": "https://registry.npmjs.org/@webex/plugin-teams/-/plugin-teams-1.80.80.tgz",
+      "integrity": "sha512-of78XADh43vw6+gSIuSn9ooCqqSxTeCpNnQ1y74QiW5cTBG3GZ0jahgZm7zS4MihEyKuVu7G9MU9v4C8VlMc+g==",
       "requires": {
-        "@webex/webex-core": "1.80.46",
+        "@webex/webex-core": "1.80.80",
         "envify": "^4.1.0"
       }
     },
     "@webex/plugin-webhooks": {
-      "version": "1.80.46",
-      "resolved": "https://registry.npmjs.org/@webex/plugin-webhooks/-/plugin-webhooks-1.80.46.tgz",
-      "integrity": "sha512-hG1Fweba3V2bu+j8uhz5UduJF/OaR4yWNYMxyLC8IGq73rQaPSkwPej+b6HabGXcdqVUnbn+aCJBbEKlSIdV8A==",
+      "version": "1.80.80",
+      "resolved": "https://registry.npmjs.org/@webex/plugin-webhooks/-/plugin-webhooks-1.80.80.tgz",
+      "integrity": "sha512-CUf17GYk39cKAY8HMTXolTsJEoNftXQJLEEo1UcGOw2o5m7FlTpbY567pv3SGNwRP06IpMFN/2vUYjLTX/Dmmg==",
       "requires": {
-        "@webex/webex-core": "1.80.46",
+        "@webex/webex-core": "1.80.80",
         "envify": "^4.1.0"
       }
     },
     "@webex/storage-adapter-local-storage": {
-      "version": "1.80.46",
-      "resolved": "https://registry.npmjs.org/@webex/storage-adapter-local-storage/-/storage-adapter-local-storage-1.80.46.tgz",
-      "integrity": "sha512-d52IAUxeMKPN76vli5IYtrzah2/jTpY0Ereqik15A12qtiiZUt4wbsjVsMPUGQlf84I6cCVj8dfnOM7CKcriZg==",
+      "version": "1.80.80",
+      "resolved": "https://registry.npmjs.org/@webex/storage-adapter-local-storage/-/storage-adapter-local-storage-1.80.80.tgz",
+      "integrity": "sha512-QNxzCx6atErx2rnVf5qDcAX7c9PnBMYr9TccIOYpYZaPRnpKkaPKv8t4SFPLFRywUs7O4oBgz8r/cRRzFUMqTg==",
       "requires": {
-        "@webex/webex-core": "1.80.46",
+        "@webex/webex-core": "1.80.80",
         "babel-runtime": "^6.26.0",
         "envify": "^4.1.0"
       }
     },
     "@webex/webex-core": {
-      "version": "1.80.46",
-      "resolved": "https://registry.npmjs.org/@webex/webex-core/-/webex-core-1.80.46.tgz",
-      "integrity": "sha512-vVwy1P1qzAK3T3PXsm45J9T+fSl4iCHujtCS3QO7OlulA7D9A4t/+4H7nN5fUgKD4WZ9vN38tKZ4kuJYJSanIw==",
+      "version": "1.80.80",
+      "resolved": "https://registry.npmjs.org/@webex/webex-core/-/webex-core-1.80.80.tgz",
+      "integrity": "sha512-NaigF7QQThny1096RaIjmlZ2A+0BqmxiV1gHeN/zs9MFWf6GkzuJH1r8fAvpYcxJQudqF4sQ5DDnsz4D2uJ4xA==",
       "requires": {
-        "@webex/common": "1.80.46",
-        "@webex/common-timers": "1.80.46",
-        "@webex/http-core": "1.80.46",
-        "@webex/webex-core": "1.80.46",
+        "@webex/common": "1.80.80",
+        "@webex/common-timers": "1.80.80",
+        "@webex/http-core": "1.80.80",
+        "@webex/webex-core": "1.80.80",
         "ampersand-collection": "^2.0.2",
         "ampersand-events": "^2.0.2",
         "ampersand-state": "^5.0.3",
@@ -605,6 +626,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/ansi-escape-sequences/-/ansi-escape-sequences-4.1.0.tgz",
       "integrity": "sha512-dzW9kHxH011uBsidTXd14JXgzye/YLb2LzeKZ4bsgl/Knwx8AtbSFkkGxagdNOoh0DlqHCmfiEjWKBaqjOanVw==",
+      "dev": true,
       "requires": {
         "array-back": "^3.0.1"
       },
@@ -612,7 +634,8 @@
         "array-back": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/array-back/-/array-back-3.1.0.tgz",
-          "integrity": "sha512-TkuxA4UCOvxuDK6NZYXCalszEzj+TLszyASooky+i742l9TqsOdYCMJJupxRic61hwquNtppB3hgcuq9SVSH1Q=="
+          "integrity": "sha512-TkuxA4UCOvxuDK6NZYXCalszEzj+TLszyASooky+i742l9TqsOdYCMJJupxRic61hwquNtppB3hgcuq9SVSH1Q==",
+          "dev": true
         }
       }
     },
@@ -635,6 +658,7 @@
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
       "requires": {
         "sprintf-js": "~1.0.2"
       }
@@ -642,7 +666,8 @@
     "array-back": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/array-back/-/array-back-4.0.1.tgz",
-      "integrity": "sha512-Z/JnaVEXv+A9xabHzN43FiiiWEE7gPCRXMrVmRm00tWbjZRul1iHm7ECzlyNq1p4a4ATXz+G9FJ3GqGOkOV3fg=="
+      "integrity": "sha512-Z/JnaVEXv+A9xabHzN43FiiiWEE7gPCRXMrVmRm00tWbjZRul1iHm7ECzlyNq1p4a4ATXz+G9FJ3GqGOkOV3fg==",
+      "dev": true
     },
     "array-next": {
       "version": "0.0.1",
@@ -688,9 +713,9 @@
       "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
     },
     "aws4": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
-      "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ=="
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.9.0.tgz",
+      "integrity": "sha512-Uvq6hVe90D0B2WEnUqtdgY1bATGz3mw33nH9Y+dmA+w5DHvUmBgkr5rM/KCHpCsiFNRUfokW/szpPPgMK2hm4A=="
     },
     "b64u": {
       "version": "2.0.0",
@@ -740,7 +765,8 @@
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
     },
     "bcrypt-pbkdf": {
       "version": "1.0.2",
@@ -753,7 +779,8 @@
     "bluebird": {
       "version": "3.7.2",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
-      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg=="
+      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
+      "dev": true
     },
     "boundary": {
       "version": "1.0.1",
@@ -770,6 +797,7 @@
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
       "requires": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -790,6 +818,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/cache-point/-/cache-point-1.0.0.tgz",
       "integrity": "sha512-ZqrZp9Hi5Uq7vfSGmNP2bUT/9DzZC2Y/GXjHB8rUJN1a+KLmbV05+vxHipNsg8+CSVgjcVVzLV8VZms6w8ZeRw==",
+      "dev": true,
       "requires": {
         "array-back": "^4.0.0",
         "fs-then-native": "^2.0.0",
@@ -811,6 +840,7 @@
       "version": "0.8.11",
       "resolved": "https://registry.npmjs.org/catharsis/-/catharsis-0.8.11.tgz",
       "integrity": "sha512-a+xUyMV7hD1BrDQA/3iPV7oc+6W26BgVJO05PGEoatMyIuPScQKsde6i3YorWX1qs+AZjnJ18NqdKoCtKiNh1g==",
+      "dev": true,
       "requires": {
         "lodash": "^4.17.14"
       }
@@ -916,6 +946,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/collect-all/-/collect-all-1.0.3.tgz",
       "integrity": "sha512-0y0rBgoX8IzIjBAUnO73SEtSb4Mhk3IoceWJq5zZSxb9mWORhWH8xLYo4EDSOE1jRBk1LhmfjqWFFt10h/+MEA==",
+      "dev": true,
       "requires": {
         "stream-connect": "^1.0.2",
         "stream-via": "^1.0.4"
@@ -948,6 +979,7 @@
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/command-line-args/-/command-line-args-5.1.1.tgz",
       "integrity": "sha512-hL/eG8lrll1Qy1ezvkant+trihbGnaKaeEjj6Scyr3DN+RC7iQ5Rz84IeLERfAWDGo0HBSNAakczwgCilDXnWg==",
+      "dev": true,
       "requires": {
         "array-back": "^3.0.1",
         "find-replace": "^3.0.0",
@@ -958,12 +990,14 @@
         "array-back": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/array-back/-/array-back-3.1.0.tgz",
-          "integrity": "sha512-TkuxA4UCOvxuDK6NZYXCalszEzj+TLszyASooky+i742l9TqsOdYCMJJupxRic61hwquNtppB3hgcuq9SVSH1Q=="
+          "integrity": "sha512-TkuxA4UCOvxuDK6NZYXCalszEzj+TLszyASooky+i742l9TqsOdYCMJJupxRic61hwquNtppB3hgcuq9SVSH1Q==",
+          "dev": true
         },
         "typical": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/typical/-/typical-4.0.0.tgz",
-          "integrity": "sha512-VAH4IvQ7BDFYglMd7BPRDfLgxZZX4O4TFcRDA6EN5X7erNJJq+McIEp8np9aVtxrCJ6qx4GTYVfOWNjcqwZgRw=="
+          "integrity": "sha512-VAH4IvQ7BDFYglMd7BPRDfLgxZZX4O4TFcRDA6EN5X7erNJJq+McIEp8np9aVtxrCJ6qx4GTYVfOWNjcqwZgRw==",
+          "dev": true
         }
       }
     },
@@ -971,6 +1005,7 @@
       "version": "0.8.0",
       "resolved": "https://registry.npmjs.org/command-line-tool/-/command-line-tool-0.8.0.tgz",
       "integrity": "sha512-Xw18HVx/QzQV3Sc5k1vy3kgtOeGmsKIqwtFFoyjI4bbcpSgnw2CWVULvtakyw4s6fhyAdI6soQQhXc2OzJy62g==",
+      "dev": true,
       "requires": {
         "ansi-escape-sequences": "^4.0.0",
         "array-back": "^2.0.0",
@@ -983,6 +1018,7 @@
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/array-back/-/array-back-2.0.0.tgz",
           "integrity": "sha512-eJv4pLLufP3g5kcZry0j6WXpIbzYw9GUB4mVJZno9wfwiBxbizTnHCw3VJb07cBihbFX48Y7oSrW9y+gt4glyw==",
+          "dev": true,
           "requires": {
             "typical": "^2.6.1"
           }
@@ -993,6 +1029,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/command-line-usage/-/command-line-usage-4.1.0.tgz",
       "integrity": "sha512-MxS8Ad995KpdAC0Jopo/ovGIroV/m0KHwzKfXxKag6FHOkGsH8/lv5yjgablcRxCJJC0oJeUMuO/gmaq+Wq46g==",
+      "dev": true,
       "requires": {
         "ansi-escape-sequences": "^4.0.0",
         "array-back": "^2.0.0",
@@ -1004,6 +1041,7 @@
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/array-back/-/array-back-2.0.0.tgz",
           "integrity": "sha512-eJv4pLLufP3g5kcZry0j6WXpIbzYw9GUB4mVJZno9wfwiBxbizTnHCw3VJb07cBihbFX48Y7oSrW9y+gt4glyw==",
+          "dev": true,
           "requires": {
             "typical": "^2.6.1"
           }
@@ -1014,22 +1052,26 @@
       "version": "2.20.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "dev": true,
       "optional": true
     },
     "common-sequence": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/common-sequence/-/common-sequence-2.0.0.tgz",
-      "integrity": "sha512-f0QqPLpRTgMQn/pQIynf+SdE73Lw5Q1jn4hjirHLgH/NJ71TiHjXusV16BmOyuK5rRQ1W2f++II+TFZbQOh4hA=="
+      "integrity": "sha512-f0QqPLpRTgMQn/pQIynf+SdE73Lw5Q1jn4hjirHLgH/NJ71TiHjXusV16BmOyuK5rRQ1W2f++II+TFZbQOh4hA==",
+      "dev": true
     },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
     },
     "config-master": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/config-master/-/config-master-3.1.0.tgz",
       "integrity": "sha1-ZnZjWQUFooO/JqSE1oSJ10xUhdo=",
+      "dev": true,
       "requires": {
         "walk-back": "^2.0.1"
       },
@@ -1037,7 +1079,8 @@
         "walk-back": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/walk-back/-/walk-back-2.0.1.tgz",
-          "integrity": "sha1-VU4qnYdPrEeoywBr9EwvDEmYoKQ="
+          "integrity": "sha1-VU4qnYdPrEeoywBr9EwvDEmYoKQ=",
+          "dev": true
         }
       }
     },
@@ -1047,9 +1090,9 @@
       "integrity": "sha1-YFiWYkBTr4wo775zXCWjAaYcZcU="
     },
     "core-js": {
-      "version": "2.6.10",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.10.tgz",
-      "integrity": "sha512-I39t74+4t+zau64EN1fE5v2W31Adtc/REhzWN+gWRRXg6WH5qAsZm62DHpQ1+Yhe4047T55jvzz7MUqF/dBBlA=="
+      "version": "2.6.11",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.11.tgz",
+      "integrity": "sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg=="
     },
     "core-util-is": {
       "version": "1.0.2",
@@ -1064,6 +1107,11 @@
         "lru-cache": "^4.0.1",
         "which": "^1.2.9"
       }
+    },
+    "crypto-js": {
+      "version": "3.1.9-1",
+      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-3.1.9-1.tgz",
+      "integrity": "sha1-/aGedh/Ad+Af+/3G6f38WeiAbNg="
     },
     "dashdash": {
       "version": "1.14.1",
@@ -1090,7 +1138,8 @@
     "deep-extend": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
-      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA=="
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "dev": true
     },
     "define-properties": {
       "version": "1.1.3",
@@ -1116,6 +1165,7 @@
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/dmd/-/dmd-4.0.5.tgz",
       "integrity": "sha512-6Pjm/Yyt2lSHFwzhXrX4FvAZ3ETR8gGVoYWVdmKNeujhV5qxPhc23vrD3FI6XHGX/3xRtItvZcFEMf5e68ex3w==",
+      "dev": true,
       "requires": {
         "array-back": "^4.0.0",
         "cache-point": "^1.0.0",
@@ -1134,7 +1184,8 @@
         "reduce-flatten": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/reduce-flatten/-/reduce-flatten-3.0.0.tgz",
-          "integrity": "sha512-eczl8wAYBxJ6Egl6I1ECIF+8z6sHu+KE7BzaEDZTpPXKXfy9SUDQlVYwkRcNTjJLC3Iakxbhss50KuT/R6SYfg=="
+          "integrity": "sha512-eczl8wAYBxJ6Egl6I1ECIF+8z6sHu+KE7BzaEDZTpPXKXfy9SUDQlVYwkRcNTjJLC3Iakxbhss50KuT/R6SYfg==",
+          "dev": true
         }
       }
     },
@@ -1230,7 +1281,8 @@
     "entities": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.2.tgz",
-      "integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w=="
+      "integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w==",
+      "dev": true
     },
     "envify": {
       "version": "4.1.0",
@@ -1278,7 +1330,8 @@
     "escape-string-regexp": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
-      "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w=="
+      "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
+      "dev": true
     },
     "esprima": {
       "version": "4.0.1",
@@ -1309,9 +1362,9 @@
       "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
     },
     "fast-json-stable-stringify": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
-      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
     },
     "fault": {
       "version": "1.0.3",
@@ -1326,6 +1379,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/file-set/-/file-set-3.0.0.tgz",
       "integrity": "sha512-B/SdeSIeRv7VlOgIjtH3dkxMI+tEy5m+OeCXfAUsirBoVoY+bGtsmvmmTFPm/G23TBY4RiTtjpcgePCfwXRjqA==",
+      "dev": true,
       "requires": {
         "array-back": "^4.0.0",
         "glob": "^7.1.5"
@@ -1340,6 +1394,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/find-replace/-/find-replace-3.0.0.tgz",
       "integrity": "sha512-6Tb2myMioCAgv5kfvP5/PkZZ/ntTpVK39fHY7WkWBgvbeE+VHd/tZuZ4mrC+bxh4cfOZeYKVPaJIZtZXV7GNCQ==",
+      "dev": true,
       "requires": {
         "array-back": "^3.0.1"
       },
@@ -1347,7 +1402,8 @@
         "array-back": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/array-back/-/array-back-3.1.0.tgz",
-          "integrity": "sha512-TkuxA4UCOvxuDK6NZYXCalszEzj+TLszyASooky+i742l9TqsOdYCMJJupxRic61hwquNtppB3hgcuq9SVSH1Q=="
+          "integrity": "sha512-TkuxA4UCOvxuDK6NZYXCalszEzj+TLszyASooky+i742l9TqsOdYCMJJupxRic61hwquNtppB3hgcuq9SVSH1Q==",
+          "dev": true
         }
       }
     },
@@ -1406,12 +1462,14 @@
     "fs-then-native": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/fs-then-native/-/fs-then-native-2.0.0.tgz",
-      "integrity": "sha1-GaEk2U2QwiyOBF8ujdbr6jbUjGc="
+      "integrity": "sha1-GaEk2U2QwiyOBF8ujdbr6jbUjGc=",
+      "dev": true
     },
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
     },
     "function-bind": {
       "version": "1.1.1",
@@ -1437,6 +1495,7 @@
       "version": "7.1.6",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
       "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+      "dev": true,
       "requires": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -1484,7 +1543,8 @@
     "graceful-fs": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.3.tgz",
-      "integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ=="
+      "integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ==",
+      "dev": true
     },
     "growl": {
       "version": "1.10.5",
@@ -1496,6 +1556,7 @@
       "version": "4.5.3",
       "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.5.3.tgz",
       "integrity": "sha512-3yPecJoJHK/4c6aZhSvxOyG4vJKDshV36VHp0iVCDVh7o9w2vwi3NSnL2MMPj3YdduqaBcu7cGbggJQM0br9xA==",
+      "dev": true,
       "requires": {
         "neo-async": "^2.6.0",
         "optimist": "^0.6.1",
@@ -1610,6 +1671,7 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
       "requires": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -1752,6 +1814,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js2xmlparser/-/js2xmlparser-4.0.0.tgz",
       "integrity": "sha512-WuNgdZOXVmBk5kUPMcTcVUpbGRzLfNkv7+7APq7WiDihpXVKrgxo6wwRpRl9OQeEBgKCVk9mR7RbzrnNWC8oBw==",
+      "dev": true,
       "requires": {
         "xmlcreate": "^2.0.0"
       }
@@ -1765,6 +1828,7 @@
       "version": "3.6.3",
       "resolved": "https://registry.npmjs.org/jsdoc/-/jsdoc-3.6.3.tgz",
       "integrity": "sha512-Yf1ZKA3r9nvtMWHO1kEuMZTlHOF8uoQ0vyo5eH7SQy5YeIiHM+B0DgKnn+X6y6KDYZcF7G2SPkKF+JORCXWE/A==",
+      "dev": true,
       "requires": {
         "@babel/parser": "^7.4.4",
         "bluebird": "^3.5.4",
@@ -1785,7 +1849,8 @@
         "underscore": {
           "version": "1.9.1",
           "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.9.1.tgz",
-          "integrity": "sha512-5/4etnCkd9c8gwgowi5/om/mYO5ajCaOgdzj/oW+0eQV9WxKBDZw5+ycmKmeaTXjInS/W0BzpGLo2xR2aBwZdg=="
+          "integrity": "sha512-5/4etnCkd9c8gwgowi5/om/mYO5ajCaOgdzj/oW+0eQV9WxKBDZw5+ycmKmeaTXjInS/W0BzpGLo2xR2aBwZdg==",
+          "dev": true
         }
       }
     },
@@ -1793,6 +1858,7 @@
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/jsdoc-api/-/jsdoc-api-5.0.4.tgz",
       "integrity": "sha512-1KMwLnfo0FyhF06TQKzqIm8BiY1yoMIGICxRdJHUjzskaHMzHMmpLlmNFgzoa4pAC8t1CDPK5jWuQTvv1pBsEQ==",
+      "dev": true,
       "requires": {
         "array-back": "^4.0.0",
         "cache-point": "^1.0.0",
@@ -1809,6 +1875,7 @@
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/file-set/-/file-set-2.0.1.tgz",
           "integrity": "sha512-XgOUUpgR6FbbfYcniLw0qm1Am7PnNYIAkd+eXxRt42LiYhjaso0WiuQ+VmrNdtwotyM+cLCfZ56AZrySP3QnKA==",
+          "dev": true,
           "requires": {
             "array-back": "^2.0.0",
             "glob": "^7.1.3"
@@ -1818,6 +1885,7 @@
               "version": "2.0.0",
               "resolved": "https://registry.npmjs.org/array-back/-/array-back-2.0.0.tgz",
               "integrity": "sha512-eJv4pLLufP3g5kcZry0j6WXpIbzYw9GUB4mVJZno9wfwiBxbizTnHCw3VJb07cBihbFX48Y7oSrW9y+gt4glyw==",
+              "dev": true,
               "requires": {
                 "typical": "^2.6.1"
               }
@@ -1827,7 +1895,8 @@
         "walk-back": {
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/walk-back/-/walk-back-3.0.1.tgz",
-          "integrity": "sha512-umiNB2qLO731Sxbp6cfZ9pwURJzTnftxE4Gc7hq8n/ehkuXC//s9F65IEIJA2ZytQZ1ZOsm/Fju4IWx0bivkUQ=="
+          "integrity": "sha512-umiNB2qLO731Sxbp6cfZ9pwURJzTnftxE4Gc7hq8n/ehkuXC//s9F65IEIJA2ZytQZ1ZOsm/Fju4IWx0bivkUQ==",
+          "dev": true
         }
       }
     },
@@ -1835,6 +1904,7 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/jsdoc-parse/-/jsdoc-parse-4.0.1.tgz",
       "integrity": "sha512-qIObw8yqYZjrP2qxWROB5eLQFLTUX2jRGLhW9hjo2CC2fQVlskidCIzjCoctwsDvauBp2a/lR31jkSleczSo8Q==",
+      "dev": true,
       "requires": {
         "array-back": "^4.0.0",
         "lodash.omit": "^4.5.0",
@@ -1848,6 +1918,7 @@
       "version": "5.0.3",
       "resolved": "https://registry.npmjs.org/jsdoc-to-markdown/-/jsdoc-to-markdown-5.0.3.tgz",
       "integrity": "sha512-tQv5tBV0fTYidRQtE60lJKxE98mmuLcYuITFDKQiDPE9hGccpeEGUNFcVkInq1vigyuPnZmt79bQ8wv2GKjY0Q==",
+      "dev": true,
       "requires": {
         "array-back": "^4.0.1",
         "command-line-tool": "^0.8.0",
@@ -1893,6 +1964,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/klaw/-/klaw-3.0.0.tgz",
       "integrity": "sha512-0Fo5oir+O9jnXu5EefYbVK+mHMBeEVEy2cmctR1O1NECcCkPRreJKrS6Qt/j3KC2C148Dfo9i3pCmCMsdqGr0g==",
+      "dev": true,
       "requires": {
         "graceful-fs": "^4.1.9"
       }
@@ -1901,6 +1973,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-2.2.0.tgz",
       "integrity": "sha512-GnAl/knGn+i1U/wjBz3akz2stz+HrHLsxMwHQGofCDfPvlf+gDKN58UtfmUquTY4/MXeE2x7k19KQmeoZi94Iw==",
+      "dev": true,
       "requires": {
         "uc.micro": "^1.0.1"
       }
@@ -1985,7 +2058,8 @@
     "lodash.camelcase": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
-      "integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY="
+      "integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY=",
+      "dev": true
     },
     "lodash.clone": {
       "version": "4.5.0",
@@ -2049,7 +2123,8 @@
     "lodash.padend": {
       "version": "4.6.1",
       "resolved": "https://registry.npmjs.org/lodash.padend/-/lodash.padend-4.6.1.tgz",
-      "integrity": "sha1-U8y6BH0G4VjTEfRdpiX05J5vFm4="
+      "integrity": "sha1-U8y6BH0G4VjTEfRdpiX05J5vFm4=",
+      "dev": true
     },
     "lodash.partialright": {
       "version": "4.2.1",
@@ -2099,6 +2174,7 @@
       "version": "8.4.2",
       "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-8.4.2.tgz",
       "integrity": "sha512-GcRz3AWTqSUphY3vsUqQSFMbgR38a4Lh3GWlHRh/7MRwz8mcu9n2IO7HOh+bXHrR9kOPDl5RNCaEsrneb+xhHQ==",
+      "dev": true,
       "requires": {
         "argparse": "^1.0.7",
         "entities": "~1.1.1",
@@ -2110,17 +2186,20 @@
     "markdown-it-anchor": {
       "version": "5.2.5",
       "resolved": "https://registry.npmjs.org/markdown-it-anchor/-/markdown-it-anchor-5.2.5.tgz",
-      "integrity": "sha512-xLIjLQmtym3QpoY9llBgApknl7pxAcN3WDRc2d3rwpl+/YvDZHPmKscGs+L6E05xf2KrCXPBvosWt7MZukwSpQ=="
+      "integrity": "sha512-xLIjLQmtym3QpoY9llBgApknl7pxAcN3WDRc2d3rwpl+/YvDZHPmKscGs+L6E05xf2KrCXPBvosWt7MZukwSpQ==",
+      "dev": true
     },
     "marked": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/marked/-/marked-0.7.0.tgz",
-      "integrity": "sha512-c+yYdCZJQrsRjTPhUx7VKkApw9bwDkNbHUKo1ovgcfDjb2kc8rLuRbIFyXL5WOEUwzSSKo3IXpph2K6DqB/KZg=="
+      "integrity": "sha512-c+yYdCZJQrsRjTPhUx7VKkApw9bwDkNbHUKo1ovgcfDjb2kc8rLuRbIFyXL5WOEUwzSSKo3IXpph2K6DqB/KZg==",
+      "dev": true
     },
     "mdurl": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-1.0.1.tgz",
-      "integrity": "sha1-/oWy7HWlkDfyrf7BAP1sYBdhFS4="
+      "integrity": "sha1-/oWy7HWlkDfyrf7BAP1sYBdhFS4=",
+      "dev": true
     },
     "mime-db": {
       "version": "1.42.0",
@@ -2147,6 +2226,7 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"
       }
@@ -2161,6 +2241,7 @@
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "dev": true,
       "requires": {
         "minimist": "0.0.8"
       },
@@ -2168,14 +2249,16 @@
         "minimist": {
           "version": "0.0.8",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+          "dev": true
         }
       }
     },
     "mkdirp2": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/mkdirp2/-/mkdirp2-1.0.4.tgz",
-      "integrity": "sha512-Q2PKB4ZR4UPtjLl76JfzlgSCUZhSV1AXQgAZa1qt5RiaALFjP/CDrGvFBrOz7Ck6McPcwMAxTsJvWOUjOU8XMw=="
+      "integrity": "sha512-Q2PKB4ZR4UPtjLl76JfzlgSCUZhSV1AXQgAZa1qt5RiaALFjP/CDrGvFBrOz7Ck6McPcwMAxTsJvWOUjOU8XMw==",
+      "dev": true
     },
     "mocha": {
       "version": "6.2.2",
@@ -2264,7 +2347,8 @@
     "neo-async": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.1.tgz",
-      "integrity": "sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw=="
+      "integrity": "sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw==",
+      "dev": true
     },
     "node-environment-flags": {
       "version": "1.0.5",
@@ -2372,7 +2456,8 @@
     "object-get": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/object-get/-/object-get-2.1.0.tgz",
-      "integrity": "sha1-ciu9tgA576R8rTxtws5RqFwCxa4="
+      "integrity": "sha1-ciu9tgA576R8rTxtws5RqFwCxa4=",
+      "dev": true
     },
     "object-inspect": {
       "version": "1.6.0",
@@ -2389,7 +2474,8 @@
     "object-to-spawn-args": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/object-to-spawn-args/-/object-to-spawn-args-1.1.1.tgz",
-      "integrity": "sha1-d9qIJ/Bz0BHJ4bFz+JV4FHAkZ4U="
+      "integrity": "sha1-d9qIJ/Bz0BHJ4bFz+JV4FHAkZ4U=",
+      "dev": true
     },
     "object.assign": {
       "version": "4.1.0",
@@ -2417,6 +2503,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
       "requires": {
         "wrappy": "1"
       }
@@ -2425,6 +2512,7 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
       "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
+      "dev": true,
       "requires": {
         "minimist": "~0.0.1",
         "wordwrap": "~0.0.2"
@@ -2433,7 +2521,8 @@
         "minimist": {
           "version": "0.0.10",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
-          "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8="
+          "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=",
+          "dev": true
         }
       }
     },
@@ -2489,7 +2578,8 @@
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
     },
     "performance-now": {
       "version": "2.1.0",
@@ -2518,9 +2608,9 @@
       "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
     },
     "psl": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/psl/-/psl-1.4.0.tgz",
-      "integrity": "sha512-HZzqCGPecFLyoRj5HLfuDSKYTJkAfB5thKBIkRHtGjWwY7p1dAyveIbXIq4tO0KYfDF2tHqPUgY9SDnGm00uFw=="
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.6.0.tgz",
+      "integrity": "sha512-SYKKmVel98NCOYXpkwUqZqh0ahZeeKfmisiLIcEZdsb+WbLv02g/dI5BUmZnIyOe7RzZtLax81nnb2HbvC2tzA=="
     },
     "punycode": {
       "version": "2.1.1",
@@ -2547,6 +2637,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/reduce-extract/-/reduce-extract-1.0.0.tgz",
       "integrity": "sha1-Z/I4W+2mUGG19fQxJmLosIDKFSU=",
+      "dev": true,
       "requires": {
         "test-value": "^1.0.1"
       },
@@ -2555,6 +2646,7 @@
           "version": "1.0.4",
           "resolved": "https://registry.npmjs.org/array-back/-/array-back-1.0.4.tgz",
           "integrity": "sha1-ZEun8JX3/898Q7Xw3DnTwfA8Bjs=",
+          "dev": true,
           "requires": {
             "typical": "^2.6.0"
           }
@@ -2563,6 +2655,7 @@
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/test-value/-/test-value-1.1.0.tgz",
           "integrity": "sha1-oJE29y7AQ9J8iTcHwrFZv6196T8=",
+          "dev": true,
           "requires": {
             "array-back": "^1.0.2",
             "typical": "^2.4.2"
@@ -2573,17 +2666,20 @@
     "reduce-flatten": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/reduce-flatten/-/reduce-flatten-1.0.1.tgz",
-      "integrity": "sha1-JYx479FT3fk8tWEjf2EYTzaW4yc="
+      "integrity": "sha1-JYx479FT3fk8tWEjf2EYTzaW4yc=",
+      "dev": true
     },
     "reduce-unique": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/reduce-unique/-/reduce-unique-2.0.1.tgz",
-      "integrity": "sha512-x4jH/8L1eyZGR785WY+ePtyMNhycl1N2XOLxhCbzZFaqF4AXjLzqSxa2UHgJ2ZVR/HHyPOvl1L7xRnW8ye5MdA=="
+      "integrity": "sha512-x4jH/8L1eyZGR785WY+ePtyMNhycl1N2XOLxhCbzZFaqF4AXjLzqSxa2UHgJ2ZVR/HHyPOvl1L7xRnW8ye5MdA==",
+      "dev": true
     },
     "reduce-without": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/reduce-without/-/reduce-without-1.0.1.tgz",
       "integrity": "sha1-aK0OrRGFXJo31OglbBW7+Hly/Iw=",
+      "dev": true,
       "requires": {
         "test-value": "^2.0.0"
       },
@@ -2592,6 +2688,7 @@
           "version": "1.0.4",
           "resolved": "https://registry.npmjs.org/array-back/-/array-back-1.0.4.tgz",
           "integrity": "sha1-ZEun8JX3/898Q7Xw3DnTwfA8Bjs=",
+          "dev": true,
           "requires": {
             "typical": "^2.6.0"
           }
@@ -2600,6 +2697,7 @@
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/test-value/-/test-value-2.1.0.tgz",
           "integrity": "sha1-Edpv9nDzRxpztiXKTz/c97t0gpE=",
+          "dev": true,
           "requires": {
             "array-back": "^1.0.3",
             "typical": "^2.6.0"
@@ -2707,6 +2805,7 @@
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/requizzle/-/requizzle-0.2.3.tgz",
       "integrity": "sha512-YanoyJjykPxGHii0fZP0uUPEXpvqfBDxWV7s6GKAiiOsiqhX6vHNyW3Qzdmqp/iq/ExbhaGbVrjB4ruEVSM4GQ==",
+      "dev": true,
       "requires": {
         "lodash": "^4.17.14"
       }
@@ -2742,6 +2841,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/sort-array/-/sort-array-2.0.0.tgz",
       "integrity": "sha1-OKnG2if9fRR7QuYFVPKBGHtN9HI=",
+      "dev": true,
       "requires": {
         "array-back": "^1.0.4",
         "object-get": "^2.1.0",
@@ -2752,6 +2852,7 @@
           "version": "1.0.4",
           "resolved": "https://registry.npmjs.org/array-back/-/array-back-1.0.4.tgz",
           "integrity": "sha1-ZEun8JX3/898Q7Xw3DnTwfA8Bjs=",
+          "dev": true,
           "requires": {
             "typical": "^2.6.0"
           }
@@ -2761,12 +2862,14 @@
     "source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true
     },
     "sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+      "dev": true
     },
     "sshpk": {
       "version": "1.16.1",
@@ -2794,6 +2897,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/stream-connect/-/stream-connect-1.0.2.tgz",
       "integrity": "sha1-GLyB8u2zW4tdmoAJIAqYUxRCipc=",
+      "dev": true,
       "requires": {
         "array-back": "^1.0.2"
       },
@@ -2802,6 +2906,7 @@
           "version": "1.0.4",
           "resolved": "https://registry.npmjs.org/array-back/-/array-back-1.0.4.tgz",
           "integrity": "sha1-ZEun8JX3/898Q7Xw3DnTwfA8Bjs=",
+          "dev": true,
           "requires": {
             "typical": "^2.6.0"
           }
@@ -2811,7 +2916,8 @@
     "stream-via": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/stream-via/-/stream-via-1.0.4.tgz",
-      "integrity": "sha512-DBp0lSvX5G9KGRDTkR/R+a29H+Wk2xItOF+MpZLLNDWbEV9tGPnqLPxHEYjmiz8xGtJHRIqmI+hCjmNzqoA4nQ=="
+      "integrity": "sha512-DBp0lSvX5G9KGRDTkR/R+a29H+Wk2xItOF+MpZLLNDWbEV9tGPnqLPxHEYjmiz8xGtJHRIqmI+hCjmNzqoA4nQ==",
+      "dev": true
     },
     "string-width": {
       "version": "2.1.1",
@@ -2860,7 +2966,8 @@
     "strip-json-comments": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.0.1.tgz",
-      "integrity": "sha512-VTyMAUfdm047mwKl+u79WIdrZxtFtn+nBxHeb844XBQ9uMNTuTHdx2hc5RiAJYqwTj3wc/xe5HLSdJSkJ+WfZw=="
+      "integrity": "sha512-VTyMAUfdm047mwKl+u79WIdrZxtFtn+nBxHeb844XBQ9uMNTuTHdx2hc5RiAJYqwTj3wc/xe5HLSdJSkJ+WfZw==",
+      "dev": true
     },
     "structured-source": {
       "version": "3.0.2",
@@ -2884,6 +2991,7 @@
       "version": "0.4.5",
       "resolved": "https://registry.npmjs.org/table-layout/-/table-layout-0.4.5.tgz",
       "integrity": "sha512-zTvf0mcggrGeTe/2jJ6ECkJHAQPIYEwDoqsiqBjI24mvRmQbInK5jq33fyypaCBxX08hMkfmdOqj6haT33EqWw==",
+      "dev": true,
       "requires": {
         "array-back": "^2.0.0",
         "deep-extend": "~0.6.0",
@@ -2896,6 +3004,7 @@
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/array-back/-/array-back-2.0.0.tgz",
           "integrity": "sha512-eJv4pLLufP3g5kcZry0j6WXpIbzYw9GUB4mVJZno9wfwiBxbizTnHCw3VJb07cBihbFX48Y7oSrW9y+gt4glyw==",
+          "dev": true,
           "requires": {
             "typical": "^2.6.1"
           }
@@ -2905,17 +3014,20 @@
     "taffydb": {
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/taffydb/-/taffydb-2.6.2.tgz",
-      "integrity": "sha1-fLy2S1oUG2ou/CxdLGe04VCyomg="
+      "integrity": "sha1-fLy2S1oUG2ou/CxdLGe04VCyomg=",
+      "dev": true
     },
     "temp-path": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/temp-path/-/temp-path-1.0.0.tgz",
-      "integrity": "sha1-JLFUOXOrRCiW2a02fdnL2/r+kYs="
+      "integrity": "sha1-JLFUOXOrRCiW2a02fdnL2/r+kYs=",
+      "dev": true
     },
     "test-value": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/test-value/-/test-value-3.0.0.tgz",
       "integrity": "sha512-sVACdAWcZkSU9x7AOmJo5TqE+GyNJknHaHsMrR6ZnhjVlVN9Yx6FjHrsKZ3BjIpPCT68zYesPWkakrNupwfOTQ==",
+      "dev": true,
       "requires": {
         "array-back": "^2.0.0",
         "typical": "^2.6.1"
@@ -2925,6 +3037,7 @@
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/array-back/-/array-back-2.0.0.tgz",
           "integrity": "sha512-eJv4pLLufP3g5kcZry0j6WXpIbzYw9GUB4mVJZno9wfwiBxbizTnHCw3VJb07cBihbFX48Y7oSrW9y+gt4glyw==",
+          "dev": true,
           "requires": {
             "typical": "^2.6.1"
           }
@@ -3001,17 +3114,20 @@
     "typical": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/typical/-/typical-2.6.1.tgz",
-      "integrity": "sha1-XAgOXWYcu+OCWdLnCjxyU+hziB0="
+      "integrity": "sha1-XAgOXWYcu+OCWdLnCjxyU+hziB0=",
+      "dev": true
     },
     "uc.micro": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.6.tgz",
-      "integrity": "sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA=="
+      "integrity": "sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA==",
+      "dev": true
     },
     "uglify-js": {
       "version": "3.7.2",
       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.7.2.tgz",
       "integrity": "sha512-uhRwZcANNWVLrxLfNFEdltoPNhECUR3lc+UdJoG9CBpMcSnKyWA94tc3eAujB1GcMY5Uwq8ZMp4qWpxWYDQmaA==",
+      "dev": true,
       "optional": true,
       "requires": {
         "commander": "~2.20.3",
@@ -3162,30 +3278,31 @@
     "walk-back": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/walk-back/-/walk-back-4.0.0.tgz",
-      "integrity": "sha512-kudCA8PXVQfrqv2mFTG72vDBRi8BKWxGgFLwPpzHcpZnSwZk93WMwUDVcLHWNsnm+Y0AC4Vb6MUNRgaHfyV2DQ=="
+      "integrity": "sha512-kudCA8PXVQfrqv2mFTG72vDBRi8BKWxGgFLwPpzHcpZnSwZk93WMwUDVcLHWNsnm+Y0AC4Vb6MUNRgaHfyV2DQ==",
+      "dev": true
     },
     "webex": {
-      "version": "1.80.46",
-      "resolved": "https://registry.npmjs.org/webex/-/webex-1.80.46.tgz",
-      "integrity": "sha512-REFu5f8zGriSOSAX9u1Tn4KjPZaYF23R7ynyIHFaHC3q9eQgpibhtX5Cvm/eiRxlArLjV3l9kg9vQBUWUQEzow==",
+      "version": "1.80.80",
+      "resolved": "https://registry.npmjs.org/webex/-/webex-1.80.80.tgz",
+      "integrity": "sha512-qjn7+kc5ydnj2eEPyfmxIUeSY1RP0cQJgg1dly6VGp+KUKABoLyt87kl25m43RgKSF4Ra9HK7zpqIhuUlXseag==",
       "requires": {
-        "@webex/internal-plugin-calendar": "1.80.46",
-        "@webex/internal-plugin-presence": "1.80.46",
-        "@webex/internal-plugin-wdm": "1.80.46",
-        "@webex/plugin-attachment-actions": "1.80.46",
-        "@webex/plugin-authorization": "1.80.46",
-        "@webex/plugin-device-manager": "1.80.46",
-        "@webex/plugin-logger": "1.80.46",
-        "@webex/plugin-meetings": "1.80.46",
-        "@webex/plugin-memberships": "1.80.46",
-        "@webex/plugin-messages": "1.80.46",
-        "@webex/plugin-people": "1.80.46",
-        "@webex/plugin-rooms": "1.80.46",
-        "@webex/plugin-team-memberships": "1.80.46",
-        "@webex/plugin-teams": "1.80.46",
-        "@webex/plugin-webhooks": "1.80.46",
-        "@webex/storage-adapter-local-storage": "1.80.46",
-        "@webex/webex-core": "1.80.46",
+        "@webex/internal-plugin-calendar": "1.80.80",
+        "@webex/internal-plugin-presence": "1.80.80",
+        "@webex/internal-plugin-wdm": "1.80.80",
+        "@webex/plugin-attachment-actions": "1.80.80",
+        "@webex/plugin-authorization": "1.80.80",
+        "@webex/plugin-device-manager": "1.80.80",
+        "@webex/plugin-logger": "1.80.80",
+        "@webex/plugin-meetings": "1.80.80",
+        "@webex/plugin-memberships": "1.80.80",
+        "@webex/plugin-messages": "1.80.80",
+        "@webex/plugin-people": "1.80.80",
+        "@webex/plugin-rooms": "1.80.80",
+        "@webex/plugin-team-memberships": "1.80.80",
+        "@webex/plugin-teams": "1.80.80",
+        "@webex/plugin-webhooks": "1.80.80",
+        "@webex/storage-adapter-local-storage": "1.80.80",
+        "@webex/webex-core": "1.80.80",
         "babel-polyfill": "^6.26.0",
         "envify": "^4.1.0",
         "lodash": "^4.17.15"
@@ -3222,12 +3339,14 @@
     "wordwrap": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-      "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc="
+      "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
+      "dev": true
     },
     "wordwrapjs": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/wordwrapjs/-/wordwrapjs-3.0.0.tgz",
       "integrity": "sha512-mO8XtqyPvykVCsrwj5MlOVWvSnCdT+C+QVbm6blradR7JExAhbkZ7hZ9A+9NUtwzSqrlUo9a67ws0EiILrvRpw==",
+      "dev": true,
       "requires": {
         "reduce-flatten": "^1.0.1",
         "typical": "^2.6.1"
@@ -3281,7 +3400,8 @@
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
     },
     "ws": {
       "version": "4.1.0",
@@ -3308,7 +3428,8 @@
     "xmlcreate": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/xmlcreate/-/xmlcreate-2.0.1.tgz",
-      "integrity": "sha512-MjGsXhKG8YjTKrDCXseFo3ClbMGvUD4en29H2Cev1dv4P/chlpw6KdYmlCWDkhosBVKRDjM836+3e3pm1cBNJA=="
+      "integrity": "sha512-MjGsXhKG8YjTKrDCXseFo3ClbMGvUD4en29H2Cev1dv4P/chlpw6KdYmlCWDkhosBVKRDjM836+3e3pm1cBNJA==",
+      "dev": true
     },
     "xtend": {
       "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webex-node-bot-framework",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Webex Teams Bot Framework for Node JS",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "moment": "^2.24.0",
     "validator": "^12.0.0",
-    "webex": "^1.80.46",
+    "webex": "^1.80.80",
     "when": "^3.7.8"
   },
   "devDependencies": {

--- a/test/as-bot/bot-created-room-tests.js
+++ b/test/as-bot/bot-created-room-tests.js
@@ -323,7 +323,7 @@ describe('User Created Room to create a Test Bot', () => {
 
     describe('bot.sendCard', () => {
       let message;
-      it.only('sends a card', () => {
+      it('sends a card', () => {
         let testName = 'bot sends a card';
         let cardJson = require('../common/input-card.json');
 
@@ -352,7 +352,7 @@ describe('User Created Room to create a Test Bot', () => {
           });
       });
 
-      it.only('presses a button on a card', () => {
+      it('presses a button on a card', () => {
         let testName = 'user presses a button on a card';
         let attachmentAction;
         let inputs = {
@@ -382,10 +382,14 @@ describe('User Created Room to create a Test Bot', () => {
           .then(() => {
             assert(validator.objIsEqual(attachmentAction, eventsData.attachmentAction),
               'attachmentAction returned by API did not match the one from the attachmentAction event');
+            // Wait for the events associated with a new message before completing test..
+            messageCreatedEvent = new Promise((resolve) => {
+              common.frameworkMessageCreatedEventHandler(testName, framework, eventsData, resolve);
+            });
             return botCreatedRoomBot.say(`Thanks. Now I know your name is ${attachmentAction.inputs.myName}, ` +
                `your email is ${attachmentAction.inputs.myEmail}, and your phone is ${attachmentAction.inputs.myTel}.`);
           })
-          .then(() => when(true))
+          .then(() => when(messageCreatedEvent))
           .catch((e) => {
             console.error(`${testName} failed: ${e.message}`);
             return Promise.reject(e);

--- a/test/bot-tests.js
+++ b/test/bot-tests.js
@@ -18,7 +18,7 @@ if ((typeof process.env.BOT_API_TOKEN === 'string') &&
   framework = new Framework({ token: process.env.BOT_API_TOKEN });
   userWebex = new Webex({ credentials: process.env.USER_API_TOKEN });
 } else {
-  console.error('Missing required evnvironment variables:\n' +
+  console.error('Missing required environment variables:\n' +
     '- BOT_API_TOKEN -- token associatd with an existing bot\n' +
     '- USER_API_TOKEN -- token associated with an existing user\n' +
     '- HOSTED_FILE -- url to a file that can be attached to test messages\n' +

--- a/test/common/common.js
+++ b/test/common/common.js
@@ -486,20 +486,20 @@ module.exports = {
       });
     },
 
-      activeBot.messageHandler = function (testName, eventsData, promiseResolveFunction) {
-        activeBot.once('message', (bot, trigger, id) => {
-          this.framework.debug(`Bot message event occurred in test ${testName}`);
-          assert(validator.isBot(bot),
-            'message event did not include a valid bot');
-          assert((bot.id === activeBot.id),
-            'bot returned in bot.on("message") is not the one expected');
-          assert(validator.isTrigger(trigger),
-            'message event did not include a valid trigger');
-          assert((id === activeBot.id),
-            'id returned in framework.on("message") is not the one expected');
-          promiseResolveFunction(true);
-        });
-      };
+    activeBot.messageHandler = function (testName, eventsData, promiseResolveFunction) {
+      activeBot.once('message', (bot, trigger, id) => {
+        this.framework.debug(`Bot message event occurred in test ${testName}`);
+        assert(validator.isBot(bot),
+          'message event did not include a valid bot');
+        assert((bot.id === activeBot.id),
+          'bot returned in bot.on("message") is not the one expected');
+        assert(validator.isTrigger(trigger),
+          'message event did not include a valid trigger');
+        assert((id === activeBot.id),
+          'id returned in framework.on("message") is not the one expected');
+        promiseResolveFunction(true);
+      });
+    };
 
     activeBot.filesHandler = function (testName, eventsData, promiseResolveFunction) {
       activeBot.once('files', (bot, trigger, id) => {

--- a/test/common/common.js
+++ b/test/common/common.js
@@ -430,6 +430,22 @@ module.exports = {
     });
   },
 
+  frameworkAttachementActionEventHandler: function (testName, framework, cardSendingBot, eventsData, promiseResolveFunction) {
+    this.framework.once('attachmentAction', (bot, trigger, id) => {
+      framework.debug(`Framework attachmentAction event occurred in test ${testName}`);
+      assert(id === framework.id);
+      assert(bot.id === cardSendingBot.id,
+        'bot returned in framework.on("attachmentAction") is not the same as the on that sent the card');
+      assert(validator.isTrigger(trigger),
+        'mentioned event did not include a valid trigger');
+      assert(trigger.type === 'attachmentAction',
+        'trigger returned in framework.on("attachmentAction") was not attachmentAction type!');
+      eventsData.attachmentAction = trigger.attachmentAction;
+      promiseResolveFunction(assert(validator.isAttachmentAction(trigger.attachmentAction),
+        'attachmentAction returned in framework.on("attachmentAction") is not valid'));
+    });
+  },
+
   frameworkDespawnHandler: function (testName, framework, eventsData, promiseResolveFunction) {
     this.framework.once('despawn', (bot, id, removedBy) => {
       framework.debug(`Framework despawn event occurred in test ${testName}`);
@@ -470,20 +486,20 @@ module.exports = {
       });
     },
 
-    activeBot.messageHandler = function (testName, eventsData, promiseResolveFunction) {
-      activeBot.once('message', (bot, trigger, id) => {
-        this.framework.debug(`Bot message event occurred in test ${testName}`);
-        assert(validator.isBot(bot),
-          'message event did not include a valid bot');
-        assert((bot.id === activeBot.id),
-          'bot returned in bot.on("message") is not the one expected');
-        assert(validator.isTrigger(trigger),
-          'message event did not include a valid trigger');
-        assert((id === activeBot.id),
-          'id returned in framework.on("message") is not the one expected');
-        promiseResolveFunction(true);
-      });
-    };
+      activeBot.messageHandler = function (testName, eventsData, promiseResolveFunction) {
+        activeBot.once('message', (bot, trigger, id) => {
+          this.framework.debug(`Bot message event occurred in test ${testName}`);
+          assert(validator.isBot(bot),
+            'message event did not include a valid bot');
+          assert((bot.id === activeBot.id),
+            'bot returned in bot.on("message") is not the one expected');
+          assert(validator.isTrigger(trigger),
+            'message event did not include a valid trigger');
+          assert((id === activeBot.id),
+            'id returned in framework.on("message") is not the one expected');
+          promiseResolveFunction(true);
+        });
+      };
 
     activeBot.filesHandler = function (testName, eventsData, promiseResolveFunction) {
       activeBot.once('files', (bot, trigger, id) => {


### PR DESCRIPTION
## v 0.5.0
* Updated framework to webex sdk v1.80.80
* Added support for attachmentAction events via webesocket.  (SDK added this in v1.80.79)
* Updated migration document to explicitly state that the framework does not support retries for pagination or 429 errors.   framework.start() will fail now if the parameters around retry logic are set.  Hope to add this back, at least for pagination, which the webex SDK provides an interface for, in the future.  -- this is in a previously merged, but not publishe to npm PR.
* Added tests for bot.[store,recall,forget].   Only tested memory storage so far.  Migrating doc still warns that redis is untested.