### PR TITLE
Mongo storage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,8 +10,8 @@ Thumbs.db
 .Spotlight-V100
 .Trashes
 
-# Application specific files
-venv
+# Environment specific files
+.env*
 node_modules
 
 # Private environments

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -15,11 +15,8 @@
       "request": "launch",
       "name": "Mocha Tests",
       "program": "${workspaceFolder}/node_modules/mocha/bin/_mocha",
-      "stopOnEntry": false,
-      "runtimeExecutable": null,
-      "env": {
-        "DEBUG": "flint"
-      },
+      "env": {"DEBUG":"framework"},
+      "cwd": "${workspaceRoot}",
       "args": [
         "--exit",
         "-u",

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2016-2019
+Copyright (c) 2016-2020
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/docs/build.sh
+++ b/docs/build.sh
@@ -15,4 +15,8 @@ echo -e "\n# Framework Reference\n\n" >> ${README}
 
 ${JSDOC} ../lib/framework.js ../lib/bot.js >> ${README}
 
+echo -e "\n# Storage Driver Reference\n\n" >> ${README}
+
+${JSDOC} ../storage/mongo.js >> ${README}
+
 cat license.md >> ${README}

--- a/docs/license.md
+++ b/docs/license.md
@@ -2,7 +2,7 @@
 
 The MIT License (MIT)
 
-Copyright (c) 2016-2017
+Copyright (c) 2016-2020
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/docs/migrate-from-node-flint.md
+++ b/docs/migrate-from-node-flint.md
@@ -47,7 +47,10 @@ Not all of the functionality in flint has been migrated to the new framework.  A
    * @property {number} [queueSize=10000] - Size of the buffer that holds outbound requests.
    * @property {number} [requeueSize=10000] - Size of the buffer that holds outbound re-queue requests.
 
-* Storage. There has been no testing of the redis version of the `bot.store()`, `bot.recall()`, `bot.forget()` functions.   While they may work, it is reccomended that developers validate this before publishing a bot that leverages redis.  
+* Storage. 
+  * There has been no testing of the redis version of the `bot.store()`, `bot.recall()`, `bot.forget()` functions.   While they may work, it is reccomended that developers validate this before publishing a bot that leverages redis.  
+  * A new framework config option `initBotStorageData` is now available.   Developers can set this to create an initial set of key/value pairs that a bot object will have when it is first spawned.
+  * A new mongo storage adaptor is available.  See the Storage Adaptor Changes for more details on how Storage Adaptors now work.
 
 ## Common migration tasks
 Alternatly, since elements of the bot and trigger objects have also changed, one might just bite the bullet, and do some search and replace.  The biggest migration tasks come from the renaming of flint to framework and the change in structures for the bot and trigger objects.  Common case sensitive search and replace tasks might include
@@ -177,3 +180,15 @@ For every message node-flint generates a set of events which may include
 Our new framework will ONLY generate the `messageCreated` event in instances when the message was sent by the bot.  In almost all cases bots and applications don't want to respond to their own messages, however those that choose to do so should build the logic for processing them in a `flint.on("messageCreated", message, flintId)` handler since the other events are no longer sent.   If any other space member posts a message, the `message` event will always fire and the `mentioned` event will fire if the message mentioned the bot, and a `files` event will fire if the message includes file attachments.
 
 
+## Storage Adaptor Changes
+For developer's who are porting existing flint based bots that use the storage adaptor capabilities there are some changes.
+
+The basic `bot.store()`, `bot.recall()`, and `bot.forget()` work as they always have when using the memory default memory storage adaptor, but there are changes in the persistent memory store adaptors.   
+
+A new mongo storage adaptor has been added which has been tested with cloud based mongo atlas DBs.   It adds several new functions:
+
+* initialize() -- this must be called before framework.start() is called and will validate that the configuration is correct
+* initStorage() -- this is called internally by the framework when a new bot is spawned.  If the new framework configuration elememnt `initBotStorageData` is set, these key/value pairs will be set on a the new bot.
+* writeMetrics() -- is a new, optional, method for storage adaptors that can be called to write breadcrumbs into the database that can be used to build reports on the bot's usage
+
+The redis adaptor is likely broken and needs to be updated to support the new functions.   It would be great if a flint user of redis wanted to [contribute](./contributing.md)!

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -83,8 +83,7 @@ framework.setWebexToken(newToken)
 ```
 
 ## Storage
-The storage system used in the framework is a simple key/value store and resolves around
-these 3 methods:
+The storage system used in the framework is a simple key/value store and resolves around these 3 methods:
 
 * `bot.store(key, value)` - Store a value to a bot instance where 'key' is a
   string and 'value' is a boolean, number, string, array, or object. *This does
@@ -96,19 +95,23 @@ these 3 methods:
   is an optional property that when defined, removes the specific key, and when
   undefined, removes all keys. Returns a resolved promise if deleted or not found.
 
+When a bot is first spawned, the framework calls the `bot.initStorage` method which attepts to load any previously existing bot storage elements (if using a persistent storage driver such as [MongoStore](#MongoStore)), or will create an optional initial set of key/value pairs that were specified in the framework's configuration options `initBotStorageData` element.   If this is not set, new bots start off with no key/value pairs until `bot.store()` is called.
+
 When a bot despawns (is removed from a space), the key/value store for that bot
 instance will automatically be removed from the store. Framework currently has an
-in-memory store and a Redis based store. By default, the in-memory store is
+in-memory store and a mongo based store. By default, the in-memory store is
 used. Other backend stores are possible by replicating any one of the built-in
-storage modules and passing it to the `framework.storeageDriver()` method. *See
-docs for store, recall, forget for more details.*
+storage modules and passing it to the `framework.storeageDriver()` method. 
 
-**Example:**
+The [MongoStore](#MongoStore) (and potentially other stores that use a persistent storage mechanism), also support the following methods:
 
-```js
-var redisDriver = require('webex-node-bot-framework/storage/redis');
-framework.storageDriver(redisDriver('redis://localhost'));
-```
+* `initialize()` -- this must be called before `framework.storageDriver()` and `framework.start()` are called, and will validate that the configuration is correct
+* `writeMetrics()` -- is a new, optional, method for persistent storage adaptors that can be called to write breadcrumbs into the database that can be used to build reports on the bot's usage
+
+See [MongoStore](#MongoStore), for details on how to configure this storage adaptor.
+
+The redis adaptor is likely broken and needs to be updated to support the new functions.   It would be great if a flint user of redis wanted to [contribute](./contributing.md)!
+
 
 ## Bot Accounts
 

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -45,7 +45,8 @@ A goal of this project was to extend the framework to support new functionality 
 node-flint provides a storage system to allow developers to store and retrieve data associated with individual bot/space combinations.   This framework has not modified that code, but has also not tested it to see if it has broken.
 
 - [x] Add storage tests
-- [ ] Add mongo storage
+- [x] Add mongo storage
+- [x] Document that redis is likely broken
 
 ## Migrating from node-flint
 - [x] Add a chart in the readme that shows the difference in the bot and trigger structures

--- a/docs/version-history.md
+++ b/docs/version-history.md
@@ -1,3 +1,10 @@
+## v 0.6.0
+* Refactored storage adaptor logic
+* `framework.storageDriver()` now returns a promise 
+* Added new Mongo storage adaptor to support bot storage that persists across server restarts
+* Added `initStorage()` method called by the framework when a bot is spawned that loads data in from database or, optionallky creates a default set of key/value pairs specified in the `initBotStorage` elment of the framework's configuration
+* Added a `writeMetrics()` method to the storage Adaptor framework, allowing developers who use a persistent storage to write bot activity data for potential engagement level reporting
+
 ## v 0.5.0
 * Updated framework to webex sdk v1.80.80
 * Added support for attachmentAction events via webesocket.  (SDK added this in v1.80.79)

--- a/lib/framework.js
+++ b/lib/framework.js
@@ -52,6 +52,7 @@ function Framework(options) {
    * @property {string} [webhookUrl] - URL that is used for Webex API to send callbacks.  If not set events are received via websocket
    * @property {string} [webhookSecret] - If specified, inbound webhooks are authorized before being processed. Ignored if webhookUrl is not set.
    * @property {string} [messageFormat=text] - Default Webex message format to use with bot.say().
+   * @property {object} [initBotStorageData={}] - Initial data for new bots to put into storage. 
    * @property {string} [id=random] - The id this instance of Framework uses.
    * @property {string} [webhookRequestJSONLocation=body] - The property under the Request to find the JSON contents.
    * @property {Boolean} [removeWebhooksOnStart=true] - If you wish to have the bot remove all account webhooks when starting. Ignored if webhookUrl is not set.
@@ -91,6 +92,8 @@ function Framework(options) {
   this.webex = {};
   this.webhook = {};
   this.cardsWebhook = {};
+
+  this.initBotStorageData = (typeof options.initBotStorageData === 'object') ? options.initBotStorageData : {};
 
   // register internal events
   this.on('error', err => {
@@ -277,10 +280,11 @@ Framework.prototype.start = function () {
     }
 
 
-    // init storage default storage driver if start is called before
+    // init storage default storage driver if none was initizlied
+    // prior to starting the framework
     if (!this.storageActive) {
-      // define default storage module
-      this.storageDriver(new MemStore());
+      this.storageDriver(new MemStore())
+        .catch((e) => console.error(`Memory storage adaptor initialization failed: ${e.message}`));
     }
 
     // init webex
@@ -1852,6 +1856,13 @@ Framework.prototype.spawn = function (membership, actorId) {
     })
     //   })
 
+    // Init the bot specific configuration in the storage adapter
+    .then(() => newBot.initStorage(this))
+    .catch((e) => {
+      console.error(`framework storage driver initStorage failed: "${e.message}. ` +
+        `New bot for space "${newBot.room.title}" may not have initial storage data!`);
+      return when(true);
+    })
 
     // No longer maintaining all memberships, just the one belonging to the bot
     // // get memberships of room
@@ -2154,13 +2165,35 @@ Framework.prototype.clearAuthorizer = function () {
  * @function
  * @memberof Framework
  * @param {Function} Driver - The storage driver.
- * @returns {null}
+ * @returns {Promise.<Boolean>} - True if driver loaded succesfully
  *
  * @example
  * // define memory store (default if not specified)
  * framework.storageDriver(new MemStore());
  */
 Framework.prototype.storageDriver = function (driver) {
+
+  // validate storage module initStorage() method
+  if (typeof driver.getName === 'function') {
+    this.storageDriverName = driver.getName();
+  } else {
+    this.storageDriverName = '';
+  }
+
+  // validate storage module initStorage() method
+  if (typeof driver.initStorage === 'function') {
+    Bot.prototype.initStorage = function (framework) {
+      if ((typeof this.room && 'object') && (typeof this.room.id === 'string')) {
+        var id = this.room.id;
+        return driver.initStorage.call(driver, id, framework.initialized, framework.initBotStorageData);
+      } else {
+        return when.reject(new Error('bot.initStorage() called when bot does not have a valid room object'));
+      }
+    };
+  } else {
+    return when.reject(new Error('storage module missing initStorage() function'));
+  }
+
 
   // validate storage module store() method
   if (typeof driver.store === 'function') {
@@ -2173,7 +2206,7 @@ Framework.prototype.storageDriver = function (driver) {
       }
     };
   } else {
-    throw new Error('storage module missing store() function');
+    return when.reject(new Error('storage module missing store() function'));
   }
 
   // validate storage module recall() method
@@ -2187,7 +2220,7 @@ Framework.prototype.storageDriver = function (driver) {
       }
     };
   } else {
-    throw new Error('storage module missing recall() function');
+    return when.reject(new Error('storage module missing recall() function'));
   }
 
   // validate storage module forget() method
@@ -2203,17 +2236,34 @@ Framework.prototype.storageDriver = function (driver) {
 
     Framework.prototype.forgetByRoomId = function (roomId) {
       return driver.forget.call(driver, roomId)
-        .catch(err => {
+        .catch(() => {
           // ignore errors when called by forgetByRoomId
           return when(true);
         });
     };
   } else {
-    throw new Error('storage module missing forget() function');
+    return when.reject(new Error('storage module missing forget() function'));
+  }
+
+  // validate or implement storage module writeMetric() method
+  if (typeof driver.writeMetric === 'function') {
+    Bot.prototype.writeMetric = function (appData, actor) {
+      if (this.active) {
+        return driver.writeMetric.call(driver, this, appData, actor);
+      } else {
+        return when(value);
+      }
+    };
+  } else {
+    // Create a no-op for this optional method
+    Bot.prototype.writeMetric = function () {
+      return when.reject(new Error(`Framework storage adaptor `+
+        `${this.framework.storageDriverName} does not support writeMetric() method`));
+    };
   }
 
   // storage defined
-  this.storageActive = true;
+  return when(this.storageActive = true);
 };
 
 /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "webex-node-bot-framework",
-  "version": "0.4.0",
+  "version": "0.6.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -808,6 +808,11 @@
       "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
       "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
       "dev": true
+    },
+    "bson": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-1.1.3.tgz",
+      "integrity": "sha512-TdiJxMVnodVS7r0BdL42y/pqC9cL2iKynVwA0Ho3qbsQYr428veL3l7BQyuqiw+Q5SqqoT0m4srSY/BlZ9AxXg=="
     },
     "btoa": {
       "version": "1.2.1",
@@ -2201,6 +2206,12 @@
       "integrity": "sha1-/oWy7HWlkDfyrf7BAP1sYBdhFS4=",
       "dev": true
     },
+    "memory-pager": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/memory-pager/-/memory-pager-1.5.0.tgz",
+      "integrity": "sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg==",
+      "optional": true
+    },
     "mime-db": {
       "version": "1.42.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.42.0.tgz",
@@ -2338,6 +2349,17 @@
       "version": "2.24.0",
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.24.0.tgz",
       "integrity": "sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg=="
+    },
+    "mongodb": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.4.1.tgz",
+      "integrity": "sha512-juqt5/Z42J4DcE7tG7UdVaTKmUC6zinF4yioPfpeOSNBieWSK6qCY+0tfGQcHLKrauWPDdMZVROHJOa8q2pWsA==",
+      "requires": {
+        "bson": "^1.1.1",
+        "require_optional": "^1.0.1",
+        "safe-buffer": "^5.1.2",
+        "saslprep": "^1.0.0"
+      }
     },
     "ms": {
       "version": "2.0.0",
@@ -2801,6 +2823,15 @@
       "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
       "dev": true
     },
+    "require_optional": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/require_optional/-/require_optional-1.0.1.tgz",
+      "integrity": "sha512-qhM/y57enGWHAe3v/NcwML6a3/vfESLe/sGM2dII+gEO0BpKRUkWZow/tyloNqJyN6kXSl3RyyM8Ll5D/sJP8g==",
+      "requires": {
+        "resolve-from": "^2.0.0",
+        "semver": "^5.1.0"
+      }
+    },
     "requizzle": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/requizzle/-/requizzle-0.2.3.tgz",
@@ -2809,6 +2840,11 @@
       "requires": {
         "lodash": "^4.17.14"
       }
+    },
+    "resolve-from": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-2.0.0.tgz",
+      "integrity": "sha1-lICrIOlP+h2egKgEx+oUdhGWa1c="
     },
     "safe-buffer": {
       "version": "5.2.0",
@@ -2820,6 +2856,15 @@
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
+    "saslprep": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/saslprep/-/saslprep-1.0.3.tgz",
+      "integrity": "sha512-/MY/PEMbk2SuY5sScONwhUDsV2p77Znkb/q3nSVstq/yQzYJOH/Azh29p9oJLsl3LnQwSvZDKagDGBsBwSooag==",
+      "optional": true,
+      "requires": {
+        "sparse-bitfield": "^3.0.3"
+      }
+    },
     "sdp-transform": {
       "version": "2.13.0",
       "resolved": "https://registry.npmjs.org/sdp-transform/-/sdp-transform-2.13.0.tgz",
@@ -2828,8 +2873,7 @@
     "semver": {
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-      "dev": true
+      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
     },
     "set-blocking": {
       "version": "2.0.0",
@@ -2864,6 +2908,15 @@
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
       "dev": true
+    },
+    "sparse-bitfield": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/sparse-bitfield/-/sparse-bitfield-3.0.3.tgz",
+      "integrity": "sha1-/0rm5oZWBWuks+eSqzM004JzyhE=",
+      "optional": true,
+      "requires": {
+        "memory-pager": "^1.0.2"
+      }
     },
     "sprintf-js": {
       "version": "1.0.3",

--- a/package.json
+++ b/package.json
@@ -1,11 +1,12 @@
 {
   "name": "webex-node-bot-framework",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Webex Teams Bot Framework for Node JS",
   "main": "index.js",
   "scripts": {
     "test": "node_modules/.bin/mocha test/bot-tests.js --exit",
     "test-as-user": "node_modules/.bin/mocha test/integration-tests.js --exit",
+    "test-mongo": "node_modules/.bin/mocha test/mongo-tests.js --exit",
     "build": "cd docs && ./build.sh && cd .."
   },
   "repository": {
@@ -27,6 +28,7 @@
   "license": "MIT",
   "dependencies": {
     "moment": "^2.24.0",
+    "mongodb": "^3.4.1",
     "validator": "^12.0.0",
     "webex": "^1.80.80",
     "when": "^3.7.8"

--- a/storage/README.md
+++ b/storage/README.md
@@ -4,4 +4,6 @@ This folder contains the storage modules that can optionally be used in Framewor
 
 If not specified, Framework will default to the "memory" module.
 
+The mongo storage module also supports a `bot.writeMetrics()` which allows bots to write metric data that can be used to track bot usage.  
+
 See the 'memory.js' module for an example, and 'template.js' as a starting point in defining your own Storage module.

--- a/storage/memory.js
+++ b/storage/memory.js
@@ -3,11 +3,48 @@
 const when = require('when');
 const _ = require('lodash');
 
-module.exports = exports = function() {
+module.exports = exports = function (config) {
   // define memstore object
   let memStore = {};
+  let defaultConfig = (config.defaultConfig) ? config.defaultConfig : {};
 
   return {
+    /**
+     * Init the global memory storage
+     *
+     * @function
+     * @returns {(Promise.<Boolean>} - True if setup
+     */
+    initialize: function () {
+      return when(true);
+    },
+
+    /**
+     * Called when a bot is spawned, this function reads in the exisitng
+     * bot configuration from the DB or creates the default one
+     *
+     *
+     * @function
+     * @param {String} id - Room/Conversation/Context ID
+     * @param {boolean} frameworkInitialized - false during framework startup
+     * @returns {(Promise.<Object>} - bot's initial config data
+     */
+    initStorage: function (id) {
+      if (typeof id === 'string') {
+        // if id does not exist, create
+        if (!memStore[id]) {
+          // create id object in memStore
+          memStore[id] = {};
+        }
+
+        if ((defaultConfig) && (typeof defaultConfig === 'object')) {
+          for (let key of Object.keys(defaultConfig)) {
+            memStore[key] = defaultConfig[key];
+          }
+        }
+      }
+    },
+
     /**
      * Store key/value data.
      *
@@ -19,15 +56,15 @@ module.exports = exports = function() {
      * @param {(String|Number|Boolean|Array|Object)} value - Value of key
      * @returns {(Promise.<String>|Promise.<Number>|Promise.<Boolean>|Promise.<Array>|Promise.<Object>)}
      */
-    store: function(id, key, value) {
-      if(typeof id === 'string') {
+    store: function (id, key, value) {
+      if (typeof id === 'string') {
         // if id does not exist, create
-        if(!memStore[id]) {
+        if (!memStore[id]) {
           // create id object in memStore
           memStore[id] = {};
         }
 
-        if(typeof key === 'string' && typeof value !== 'undefined') {
+        if (typeof key === 'string' && typeof value !== 'undefined') {
           memStore[id][key] = value;
           return when(memStore[id][key]);
         } else {
@@ -49,12 +86,12 @@ module.exports = exports = function() {
      * @param {String} [key] - Key under id object (optional). If key is not passed, all keys for id are returned as an object.
      * @returns {(Promise.<String>|Promise.<Number>|Promise.<Boolean>|Promise.<Array>|Promise.<Object>)}
      */
-    recall: function(id, key) {
-      if(typeof id === 'string') {
+    recall: function (id, key) {
+      if (typeof id === 'string') {
         // if key is defined and of type string....
-        if(typeof key === 'string') {
+        if (typeof key === 'string') {
           // if id/key exists...
-          if(memStore[id] && memStore[id][key]) {
+          if (memStore[id] && memStore[id][key]) {
             return when(memStore[id][key]);
           } else {
             return when.reject(new Error('bot.recall() could not find the value referenced by id/key'));
@@ -62,9 +99,9 @@ module.exports = exports = function() {
         }
 
         // else if key is not defined
-        else if(typeof key === 'undefined') {
+        else if (typeof key === 'undefined') {
           // if id exists...
-          if(memStore[id]) {
+          if (memStore[id]) {
             return when(memStore[id]);
           } else {
             return when.reject(new Error('bot.recall() has no key/values defined'));
@@ -90,12 +127,12 @@ module.exports = exports = function() {
      * @param {String} [key] - Key under id object (optional). If key is not passed, id and all children are removed.
      * @returns {(Promise.<String>|Promise.<Number>|Promise.<Boolean>|Promise.<Array>|Promise.<Object>)}
      */
-    forget: function(id, key) {
-      if(typeof id === 'string') {
+    forget: function (id, key) {
+      if (typeof id === 'string') {
         // if key is defined and of type string....
-        if(typeof key === 'string') {
+        if (typeof key === 'string') {
           // if id/key exists...
-          if(memStore[id] && memStore[id][key]) {
+          if (memStore[id] && memStore[id][key]) {
             let deletedKey = _.cloneDeep(memStore[id][key]);
             delete memStore[id][key];
             return when(deletedKey);
@@ -105,9 +142,9 @@ module.exports = exports = function() {
         }
 
         // else if key is not defined
-        else if(typeof key === 'undefined') {
+        else if (typeof key === 'undefined') {
           // if id exists...
-          if(memStore[id]) {
+          if (memStore[id]) {
             let deletedId = _.cloneDeep(memStore[id]);
             delete memStore[id];
             return when(deletedId);

--- a/storage/mongo.js
+++ b/storage/mongo.js
@@ -1,0 +1,485 @@
+/*
+* mongo.js
+* 
+* This module implments a storage interface for bots built using
+* the webex-node-botkit-framework.  Data is stored in a mongo
+* database, but also stored locally in a memory store for fast
+* lookups which are used when configured with the singleInstance option.
+*
+*  Writes lazily update the database
+*  
+*/
+const when = require('when');
+var _ = require('lodash');
+var debug = require('debug')('mongo');
+
+var mongo_client = require('mongodb').MongoClient;
+
+
+class MongoStore {
+  /**
+   * Creates an instance of the Mongo Storage Adaptor.
+   * This storage adaptor uses a Mongo database that allows
+   * bot storage information to persist across server restarts.
+   * It has been tested with cloud mongo db conections and requires
+   * mondodb driver 3.4 or greater.
+   * @module MongoStore
+   * @constructor MongoStore
+   * @param {Object} config - Configuration object containing mongo db and collection settings.
+   *
+   * @example
+   * var config = {
+   *   mongoUri: 'mongodb://[username:password@]host1[:port1][,...hostN[:portN]][/[database][?options]]',
+   *   storageCollectionName: 'webexBotFrameworkStorage'
+   * };
+   * let MongoStore = require('webex-node-bot-framework/storage/mongo');
+   * let mongoStore = new MongoStore(config);
+   */
+
+  constructor(config) {
+    this.canInitiatilize = false;
+    this.name = 'mongo';
+
+    /**
+     * Options Object
+     *
+     * @memberof MongoStore
+     * @instance
+     * @namespace config
+     * @property {string} mongoUri - URI to connect to Mongo.
+           This is typically in the format of:\n mongodb+srv://[username:password@]host1[:port1][,...hostN[:portN]][/[database][?options]],
+           ie: mongodb+srv://myUser:secretPassw0rd@cluster#-area.mongodb.net/myClusterDBName?retryWrites=true&w=majority`,
+           see:  https://docs.mongodb.com/manual/reference/connection-string/
+     * @property {string} [storageCollectionName=webexBotFramworkStorage] - Mongo collection name for bot.[store,recall]() (will be created if does not exist)
+     * @property {object} [initBotStorageData={}] - Object with any default key/value pairs that a new bot should get upon creation 
+     * @property {string} [metricsCollectionName] - Mongo collection name for bot.writeMetric() (will be created if set, but does not exist),
+     *     bot.writeMetric() calls will fail if this is not set
+     * @property {Boolean} [singleInstance=false] - Optimize bot.recall() speed if the bot is only running a single instance.
+     *     Data is still written to db, but lookups are done from local memory
+     *     Should be used with caution!
+     */
+
+    if (!config.mongoUri) {
+      console.error('MongoStore config object is missing required mongoUri parameter.  Persistent storage will not be available');
+      return;
+    }
+    this.canInitialize = true;
+    this.initizalized = false;
+    this.config = config;
+
+    // Use default storage collection name if none set
+    this.config.metricsCollectionName = (config.metricsCollectionName) ? config.metricsCollectionName : 'webexBotFramworkStorage';
+
+    // As an optimization this storage adapter can run in "single instance" mode and do "recalls" from memory
+    // Developers should set this only if they are SURE that only one instance of the bot is running.
+    // If its behind a load balancer, recalls should always check the DB in case another instance updated
+    this.config.singleInstance = (config.singleInstance) ? config.singleInstance : false;
+
+    // We keep a copy of the bots' storage in memory for fast lookups
+    // TODO (completely skip this if we are not in single instance mode?)
+    this.memStore = {};
+
+    // this.connectUrl = encodeURI(`mongodb+srv://${config.mongoUser}:${config.mongoPass}@${config.mongoConnectionStringSuffix}`);
+    // this.connectUrl = encodeURI(`mongodb+srv://tropoBot:7M9rdmW6Goq1yAwg@cluster0-5rfnd.mongodb.net/new-cardSchool-dev?retryWrites=true&w=majority`);
+    this.connectUrl = encodeURI(config.mongoUri);
+  }
+
+  /**
+   * Initializes the connection to the db.
+   * Call this, and wait for the return before setting the 
+   * framework's storage adaptor, and then calling framework.start()
+   *
+   * @function
+   * @returns {(Promise.<Boolean>)} - True if setup
+   * 
+   * @example
+   *  // Wait for the connection to the DB to initialize before setting the
+   *  // framework's storage driver and starting framework
+   *  mongoStore.initialize()
+   *    .then(() => framework.storageDriver(mongoStore))
+   *    .then(() => framework.start())
+   *    .catch((e) => {
+   *      console.error(`Initialization with mongo storage failed: ${e.message}`)
+   *      process.exit(-1);
+   *   });
+   */
+  initialize() {
+    // Connect to the mongoDB using the user,pass and url from the config
+    return mongo_client.connect(this.connectUrl,
+      {
+        useUnifiedTopology: true,
+        useNewUrlParser: true,
+      })
+      .then((client) => {
+        this.client = client;
+        // Open (or create) the collection specified in the config
+        return this.client.db().collection(this.config.storageCollectionName);
+      })
+      .then((storeCollection) => {
+        this.botStoreCollection = storeCollection;
+        // If specified, open, or create a metrics collection
+        if (this.config.metricsCollectionName) {
+          return this.client.db().collection(this.config.metricsCollectionName);
+        } else {
+          return when('');
+        }
+      })
+      .then((metricsCollection) => {
+        if ((this.config.metricsCollectionName) && (metricsCollection)) {
+          this.metricsStoreCollection = metricsCollection;
+        }
+        this.initialized = true;
+        return when(this.initialized);
+      })
+      .catch((e) => {
+        return when.reject(new Error(`MongoStore.initialize() failure: ${e.message}`));
+      });
+  }
+
+  /**
+   * Get the storage adaptor's name
+   *
+   * @function
+   * @returns {string} - storage adaptor name
+   */
+  getName() {
+    return this.name;
+  };
+
+  /**
+   * Called by the framework, when a bot is spawned,
+   * this function reads in any existng bot configuration from the DB
+   * or creates the default one if none is found
+   * 
+   * In general bot developers should not need to call this method
+   *
+   * @function
+   * @param {String} id - Room/Conversation/Context ID
+   * @param {boolean} frameworkInitialized - false during framework startup
+   * @param {object} initBotStorageData - data to initialize a new bot with
+   * @returns {(Promise.<Object>)} - bot's initial or previously stored config data
+   */
+  initStorage(id, frameworkInitialized, initBotStorageData) {
+    if ((!this.initialized) || (!this.botStoreCollection)) {
+      if (!this.config.singleInstance) {
+        return when.reject(new Error('MongoStore.spawn() called when store is not initialized!'));
+      }
+      debug(`No DB available. Will use default config for roomId: "${id}".  Settings will not persist across restarts.`);
+      if (typeof initBotStorageData != 'object') {
+        initBotStorageData = {};
+      }
+      this.memStore[id] = initBotStorageData;
+      return when(initBotStorageData);
+    }
+
+    if (!frameworkInitialized) {
+      // Look for an existing storeConfig in the DB
+      return this.botStoreCollection.findOne({ '_id': id })
+        .then((dbStore) => {
+          if (dbStore !== null) {
+            debug(`Found stored config for existing spaceId: "${id}"`);
+            this.memStore[id] = dbStore;
+            return when(this.memStore[id]);
+          } else {
+            debug(`Did not find stored config for existing spaceId: "${id}"`);
+            return this.createDefaultConfig(id, initBotStorageData);
+          }
+        })
+        .catch((e) => {
+          this.logger.error(`Failed to contact DB on bot spawn for spaceId "${id}": ${e.message}.  Using default config`);
+          return this.createDefaultConfig(id, initBotStorageData);
+        });
+    } else {
+      // Start with the default config when our bot is added to a new space
+      return this.createDefaultConfig(id, initBotStorageData);
+    }
+  };
+
+  createDefaultConfig(id, initStorage) {
+    debug(`Attempting to store default config for spaceId "${id}"`);
+    let initBotStorageData = JSON.parse(JSON.stringify(initStorage));
+    initBotStorageData._id = id;
+    this.memStore[id] = initBotStorageData;
+    return this.botStoreCollection.insertOne(initBotStorageData, { upsert: true, w: 1 })
+      .then((mReturn) => {
+        debug(`Mongo response when creating default store config for spaceId: ${id}:`);
+        debug(mReturn);
+      })
+      .catch((e) => {
+        console.error(`Failed to store default config for spaceId: "${id}": ${e.message}`);
+        return when(initBotStorageData);
+      });
+  };
+
+  /**
+   * Store key/value data.
+   *
+   * This method is exposed as bot.store(key, value);
+   *
+   * @function
+   * @param {String} id - Room/Conversation/Context ID
+   * @param {String} key - Key under id object
+   * @param {(String|Number|Boolean|Array|Object)} value - Value of key
+   * @returns {(Promise.<String>|Promise.<Number>|Promise.<Boolean>|Promise.<Array>|Promise.<Object>)} -- stored value
+   */
+  store(id, key, value) {
+    let skipDbWrites = false;
+    if ((!this.initialized) || (!this.botStoreCollection)) {
+      if (!this.config.singleInstance) {
+        return when.reject(new Error('MongoStore.store() called when store is not initialized!'));
+      } else {
+        skipDbWrites = true;
+        debug(`MongoStore.store(): No DB will use in-memory config for spaceId: "${id}".  Settings will not persist across restarts.`);
+      }
+    }
+
+    if (typeof id !== 'string') {
+      return when.reject(new Error(`Failed to store {${key}: ${value}}.  Invalid bot spaceId.`));
+    }
+
+    if (!this.memStore[id]) {
+      // Paranoia here, should not happen
+      this.memStore[id] = { _id: id };
+    }
+
+    if (key) {
+      this.memStore[id][key] = value;
+      if (skipDbWrites) {
+        return when(this.memStore[id][key]);
+      }
+      return this.botStoreCollection.replaceOne(
+        { _id: id }, this.memStore[id], { upsert: true })
+        .catch((e) => {
+          return when.reject(new Error(`Failed DB storeConfig update spaceId: "${id}": ${e.message}`));
+        });
+    }
+    return when.reject(new Error('invalid args'));
+  };
+
+  /**
+   * Recall value of data stored by 'key'.
+   *
+   * This method is exposed as bot.recall(key, value);
+   *
+   * @function
+   * @param {String} id - Room/Conversation/Context ID
+   * @param {String} [key] - Key under id object (optional). If key is not passed, all keys for id are returned as an object.
+   * @returns {(Promise.<String>|Promise.<Number>|Promise.<Boolean>|Promise.<Array>|Promise.<Object>)} -- recalled value
+   */
+  recall(id, key) {
+    let skipDbReads = false;
+    if ((!this.initialized) || (!this.botStoreCollection)) {
+      if (!this.config.singleInstance) {
+        return when.reject(new Error('MongoStore.recall() called when store is not initialized!'));
+      } else {
+        skipDbReads = true;
+        debug(`MongoStore.recall(): No DB will use in-memory config for spaceId: "${id}".  Settings will not persist across restarts.`);
+      }
+    }
+
+    if (typeof id !== 'string') {
+      return when.reject(new Error(`Failed to bot.recall(${key}).  Invalid bot object.`));
+    }
+
+    if ((this.config.singleInstance) || (skipDbReads)) {
+      // if key is defined and of type string....
+      if (typeof key === 'string') {
+        // if id/key exists...
+        if (this.memStore[id] && this.memStore[id][key]) {
+          return when(this.memStore[id][key]);
+        } else {
+          return when.reject(new Error('bot.recall() could not find the value referenced by id/key'));
+        }
+      }
+
+      // else if key is not defined
+      else if (typeof key === 'undefined') {
+        // if id exists...
+        if (this.memStore[id]) {
+          return when(this.memStore[id]);
+        } else {
+          return when.reject(new Error('bot.recall() has no key/values defined'));
+        }
+      }
+
+      // else key is defined, but of wrong type
+      else {
+        return when.reject(new Error('bot.recall() key must be of type "string"'));
+      }
+
+    } else {
+      // Todo optimize this to use projection operators and get only the key needed
+      return this.botStoreCollection.findOne({ _id: id })
+        .then((remoteConfig) => {
+          this.memStore[id] = remoteConfig;
+          if (key) {
+            if (key in this.memStore[id]) {
+              return when(this.memStore[id][key]);
+            } else {
+              return when.reject(new Error(`Failed to find ${key} in recall() for spaceId "${id}"`));
+            }
+          } else {
+            return when(this.memStore[id]);
+          }
+        })
+        .catch((e) => {
+          return when.reject(new Error(`Failed to find ${key} in recall() for spaceId "${id}"`));
+        });
+    }
+  };
+
+  /**
+   * Forget a key or entire store.
+   *
+   * This method is exposed as bot.forget(key, value);
+   *
+   * @function
+   * @param {String} id - Room/Conversation/Context ID
+   * @param {String} [key] - Key to forget (optional). If key is not passed, all stored configs are removed.
+   * @returns {(Promise.<String>|Promise.<Number>|Promise.<Boolean>|Promise.<Array>|Promise.<Object>)}
+   */
+  forget(id, key) {
+    let skipDbWrites = false;
+    if ((!this.initialized) || (!this.botStoreCollection)) {
+      if (!this.config.singleInstance) {
+        return when.reject(new Error('MongoStore.forget() called when store is not initialized!'));
+      } else {
+        skipDbWrites = true;
+        debug(`MongoStore.forget(): No DB will use in-memory config for spaceID: "${id}".  Settings will not persist across restarts.`);
+      }
+    }
+
+    if (typeof id !== 'string') {
+      return when.reject(new Error(`Failed to forget ${key}.  Invalid bot object.`));
+    }
+
+    if ((!((this.config.singleInstance) || (skipDbWrites))) && (typeof key !== 'undefined')) {
+      return this.botStoreCollection.findOne({ _id: id })
+        .then((remoteConfig) => {
+          this.memStore[id] = remoteConfig;
+          return this.doForget(id, key, skipDbWrites);
+        });
+    } else {
+      return this.doForget(id, key, skipDbWrites);
+    }
+  }
+
+  /* Internal helper to work with memory version */
+  doForget(id, key, skipDbWrites) {
+    let val;
+    if (key) {
+      if (key in this.memStore[id]) {
+        val = _.cloneDeep(this.memStore[id][key]);
+        delete this.memStore[id][key];
+      } else {
+        return when.reject(new Error(`Failed to find ${key} in forget() for spaceId "${id}"`));
+      }
+    } else {
+      // Delete the entire store if no key is set
+      this.memStore[id] = {};
+      if (!skipDbWrites) {
+        return this.botStoreCollection.deleteOne({ _id: id })
+          .then((mongoResponse) => {
+            debug('Mongo response from deleting store config in bot.forget():');
+            debug(mongoResponse);
+            return when(val);
+          })
+          .catch((e) => {
+            return when(new Error(`Failed DB storeConfig delete for spaceId: "${id}": ${e.message}`));
+          });
+      }
+    }
+    if (skipDbWrites) {
+      return when(val);
+    } else {
+      return this.botStoreCollection.replaceOne(
+        { _id: id }, this.memStore[id], { upsert: true, w: 1 })
+        .then((mongoResponse) => {
+          debug('Mongo response from updating store config in bot.forget():');
+          debug(mongoResponse);
+          return when(val);
+        })
+        .catch((e) => {
+          return when(new Error(`Failed DB storeConfig update spaceId: "${id}": ${e.message}`));
+        });
+    }
+  }
+
+  /**
+   * Write a metrics object to the database
+   *
+   * This method is exposed as bot.writeMetric(appData, actor);
+   *
+   * @function
+   * @param {object} bot - bot that is writing the metric
+   * @param {object} appData - app specific metric data.
+   * @param {object|string} actor - user that triggered the metric activity
+   * @returns {(Promise.<Object>)} - final data object written
+   */
+  writeMetric(bot, appData, actor) {
+    if (typeof appData !== 'object') {
+      return when.reject(new Error('writeMetric() requires an appData object. ' +
+        'Best practice is to include a field called "event"'));
+    }
+    let event = appData.event;
+    if (!this.metricsStoreCollection) {
+      return when.reject(new Error(`MongoStore.writeMetris(), no metrics collection ` +
+        `available.  Metric data for ${event} is lost.`));
+    }
+    if ((typeof bot !== 'object') || (!('room' in bot))) {
+      return when.reject(new Error(`Invalid bot object passed to writeMetric() call.  Metric data for ${event} is lost.`));
+    }
+
+    let data = appData;
+    //TODO do I want to add any indices to this?
+    data.botName = bot.person.displayName;
+    data.spaceId = bot.room.id;
+    data.spaceName = bot.room.title;
+    data.spaceType = bot.room.type;
+    data.date = new Date().toISOString();
+    data._id = `${bot.room.id}_${data.date}`;
+
+    // If we have actor info add that to the data
+    if (actor) {
+      if (typeof actor === 'string') {
+        return bot.webex.people.get(actor)
+          .then((actorPerson) => this.writeMetricWithActorData(data, actorPerson))
+          .catch((e) => {
+            debug(`Unable to get actor info for ${event}: ${e.message}.  Will write metric without it.`);
+            return this.writeMetricWithActorData(data, null);
+          });
+      } else {
+        return this.writeMetricWithActorData(data, actor);
+      }
+    } else {
+      return this.writeMetricWithActorData(data, null);
+    }
+  };
+
+  /* Internal helper to write metrics after a syncrounous or async actor lookup */
+  writeMetricWithActorData(data, actorPerson) {
+    try {
+      if (actorPerson) {
+        data.actorEmail = actorPerson.emails[0];
+        data.actorDisplayName = actorPerson.displayName;
+        data.actorDomain = _.split(_.toLower(data.actorEmail), '@', 2)[1];
+        data.actorOrgId = actorPerson.orgId;
+      }
+    } catch (e) {
+      debug(`Unable to get actor info for metrics event.  Will write metric without it.`);
+    }
+    return this.metricsStoreCollection.insertOne(data)
+      .then((mResponse) => {
+        if (mResponse.insertedCount != 1) {
+          debug(`writeMetrics() Got unexpected Mongo.insertedCount: ${mResponse.insertedCount}`);
+        }
+        return when(mResponse.ops[0]);
+      })
+      .catch((e) => {
+        return when.reject(new Error(`Failed writing metric to dabease: ${e.message}.  Metric data is lost`));
+      });
+  };
+
+};
+
+module.exports = MongoStore;

--- a/storage/redis.js
+++ b/storage/redis.js
@@ -8,10 +8,62 @@ const _ = require('lodash');
 const jsonParse = when.lift(JSON.parse);
 const jsonStringify = when.lift(JSON.stringify);
 
-module.exports = exports = function(connectionUrl) {
+module.exports = exports = function (connectionUrl) {
   const redis = Redis.createClient({ url: connectionUrl });
+  const name = 'redis'
 
   return {
+
+    /**
+     * Init the global memory storage
+     * 
+     * This has never been tested.  Validating connections
+     * work here and throwing an exception when they don't 
+     * could be handy
+     *
+     * @function
+     * @returns {(Promise.<Boolean>} - True if setup
+     */
+    initialize: function () {
+      return when(true);
+    },
+
+
+    /**
+     * Get the storage adaptor's name
+     *
+     * @function
+     * @returns {string} - storage adaptor name
+     */
+    getName: function () {
+      return name;
+    },
+
+    /**
+     * Called when a bot is spawned, this function reads in the exisitng
+     * bot configuration from the DB or creates the default one
+     *
+     * This has never been tested and needs help from a redis user
+     *
+     * @function
+     * @param {String} id - Room/Conversation/Context ID
+     * @param {boolean} frameworkInitialized - false during framework startup
+     * @param {object} initBotData - object that contains the key/value pairs that should be set for new bots
+     * @returns {(Promise.<Object>} - bot's initial config data
+     */
+    initStorage: function (id, frameworkInitialized, initBotData) {
+      if (frameworkInitialized) {
+        // see if any exising data is in redis...
+      } else {
+        // Storage adaptors with persistent memory will add the initial 
+        // data only for "new" bots which are created after the framewor
+        // is initialized.   
+        if ((initBotData) && (typeof initBotData === 'object')) {
+          // Add this data to redis for this bot/space
+        }
+        return when(initBotData);
+      }
+    },
 
     /**
      * Store key/value data.
@@ -24,7 +76,7 @@ module.exports = exports = function(connectionUrl) {
      * @param {(String|Number|Boolean|Array|Object)} value - Value of key
      * @returns {(Promise.<String>|Promise.<Number>|Promise.<Boolean>|Promise.<Array>|Promise.<Object>)}
      */
-    store: function(id, key, value) {
+    store: function (id, key, value) {
       if (id && key) {
         if (value) {
           return jsonStringify(value)
@@ -57,7 +109,7 @@ module.exports = exports = function(connectionUrl) {
      * @param {String} [key] - Key under id object (optional). If key is not passed, all keys for id are returned as an object.
      * @returns {(Promise.<String>|Promise.<Number>|Promise.<Boolean>|Promise.<Array>|Promise.<Object>)}
      */
-    recall: function(id, key) {
+    recall: function (id, key) {
       if (id) {
         if (key) {
           return when.promise((resolve, reject) => redis.hget(id, key, (err, result) => {
@@ -100,7 +152,7 @@ module.exports = exports = function(connectionUrl) {
      * @param {String} [key] - Key under id object (optional). If key is not passed, id and all children are removed.
      * @returns {(Promise.<String>|Promise.<Number>|Promise.<Boolean>|Promise.<Array>|Promise.<Object>)}
      */
-    forget: function(id, key) {
+    forget: function (id, key) {
       if (id) {
         if (key) {
           return when.promise((resolve, reject) => redis.hdel(id, key, (err, result) => {

--- a/storage/template.js
+++ b/storage/template.js
@@ -2,9 +2,52 @@
 
 'use strict';
 
-module.exports = exports = function() {
+module.exports = exports = function () {
+  // define adaptor name and any other objects needed
+  const name = "template";
 
   return {
+    /**
+     * Init the adaptor
+     * 
+     * Users can call this to validate connectivity to the DB is working
+     * Return a rejct if there is a problem with the configuration
+     *
+     * @function
+     * @returns {(Promise.<Boolean>} - True if setup
+     */
+    initialize: function () {
+      return when(true);
+    },
+
+    /**
+     * Get the storage adaptor's name
+     *
+     * @function
+     * @returns {string} - storage adaptor name
+     */
+    getName: function () {
+      return name;
+    },
+
+    /**
+     * Called when a bot is spawned, this function reads in the exisitng
+     * bot configuration from the DB or creates the default one
+     *
+     *
+     * @function
+     * @param {String} id - Room/Conversation/Context ID
+     * @param {boolean} frameworkInitialized - false during framework startup
+     * @param {object} initBotData - object that contains the key/value pairs that should be set for new bots
+     * @returns {(Promise.<Object>} - bot's initial config data
+     */
+    initStorage: function (id, frameworkInitialized, initBotData) {
+      // if framework is initialized check store for id
+      // if not found or framework is not initizlied set the initial bot data passed in
+      // if success, return promise that resolves to initBotData
+      // if failure, returns a rejected promise
+    },
+
     /**
      * Store key/value data.
      *
@@ -16,7 +59,7 @@ module.exports = exports = function() {
      * @param {(String|Number|Boolean|Array|Object)} value - Value of key
      * @returns {(Promise.<String>|Promise.<Number>|Promise.<Boolean>|Promise.<Array>|Promise.<Object>)}
      */
-    store: function(id, key, value) {
+    store: function (id, key, value) {
       // if id does not exist, create
       // if success, return promise that resolves to value
       // if failure, returns a rejected promise
@@ -32,7 +75,7 @@ module.exports = exports = function() {
      * @param {String} [key] - Key under id object (optional). If key is not passed, all keys for id are returned as an object.
      * @returns {(Promise.<String>|Promise.<Number>|Promise.<Boolean>|Promise.<Array>|Promise.<Object>)}
      */
-    recall: function(id, key) {
+    recall: function (id, key) {
       // if exists, returns promise that resolves to value of id/key referenced
       // if does not exist, or a failure, returns a rejected promise
     },
@@ -47,7 +90,7 @@ module.exports = exports = function() {
      * @param {String} [key] - Key under id object (optional). If key is not passed, id and all children are removed.
      * @returns {(Promise.<String>|Promise.<Number>|Promise.<Boolean>|Promise.<Array>|Promise.<Object>)}
      */
-    forget: function(id, key) {
+    forget: function (id, key) {
       // if exists, returns promise that resolves to value of deleted value
       // if does not exist, or a failure, returns a rejected promise
     }

--- a/test/as-bot/bot-created-room-tests.js
+++ b/test/as-bot/bot-created-room-tests.js
@@ -91,7 +91,7 @@ describe('User Created Room to create a Test Bot', () => {
         });
     });
 
-    it('checks for non-existent testString', () => {
+    it('checks for forgotten testString', () => {
       let element = 'testString';
       let testName = `check for non existent storage element ${element}`;
       bot = userCreatedRoomBot;
@@ -107,7 +107,7 @@ describe('User Created Room to create a Test Bot', () => {
         });
     });
 
-    it('checks for non-existent testObject', () => {
+    it('checks for forgotten testObject', () => {
       let element = 'testObject';
       let testName = `check for non existent storage element ${element}`;
       bot = userCreatedRoomBot;

--- a/test/bot-tests.js
+++ b/test/bot-tests.js
@@ -15,7 +15,19 @@ require('dotenv').config();
 if ((typeof process.env.BOT_API_TOKEN === 'string') &&
   (typeof process.env.USER_API_TOKEN === 'string') &&
   (typeof process.env.HOSTED_FILE === 'string')) {
-  framework = new Framework({ token: process.env.BOT_API_TOKEN });
+  frameworkOptions = { token: process.env.BOT_API_TOKEN };
+  if (typeof process.env.INIT_STORAGE === 'string') {
+    try {
+      frameworkOptions.initBotStorageData = JSON.parse(process.env.INIT_STORAGE);
+    } catch (e) {
+      console.error(`Unable to parse INIT_STORAGE value:${process.env.INIT_STORAGE}`);
+      console.error(`${e.message}`);
+      console.error('Make sure to set this to optional environment to a '+
+        'properly stringified JSON object in order to test that the storage adapter properly adds it to new bots.');
+      process.exit(-1);
+    }
+  }
+  framework = new Framework(frameworkOptions);
   userWebex = new Webex({ credentials: process.env.USER_API_TOKEN });
 } else {
   console.error('Missing required environment variables:\n' +

--- a/test/common/bot-direct-message-tests.js
+++ b/test/common/bot-direct-message-tests.js
@@ -9,7 +9,7 @@ let when = common.when;
 
 
 describe('Bot interacts with user in 1-1 space', () => {
-
+  let frameworkTestRuns = 0;
   let testName = 'Bot 1-1 Space Test';
   let message;
   let eventsData = {};
@@ -36,6 +36,26 @@ describe('Bot interacts with user in 1-1 space', () => {
     });
   });
 
+
+
+  it('checks for persistent storage from previous tests', () => {
+    let bot = common.botForUser1on1Space;
+    if (process.env.MONGO_USER) {
+      return bot.recall('frameworkTestRuns')
+        .then((count) => {
+          frameworkTestRuns = count;
+          framework.debug(`Found persistent config "frameworkTestRuns": ${count}`);
+          return Promise.resolve(true);
+        })
+        .catch((e) => {
+          return Promise.reject(new Error(`Did not find persistent config "frameworkTestRuns": ${e.message}` +
+            ` This is expected the first time the test is run`));
+        });
+    } else {
+      framework.debug('Skipping persistent storage test for non Mongo storage provider');
+      return Promise.resolve(true);
+    }
+  });
 
   it('hears the user without needing to be mentioned', () => {
     testName = 'hears the user without needing to be mentioned';
@@ -137,5 +157,17 @@ describe('Bot interacts with user in 1-1 space', () => {
       });
   });
 
+  it('updates persistent storage for the next tests', () => {
+    let bot = common.botForUser1on1Space;
+    if (process.env.MONGO_USER) {
+      return bot.store('frameworkTestRuns', frameworkTestRuns + 1)
+        .catch((e) => {
+          return Promise.reject(new Error(`Failed to update persistent config "frameworkTestRuns": ${e.message}`));
+        });
+    } else {
+      framework.debug('Skipping persistent storage test for non Mongo storage provider');
+      return Promise.resolve(true);
+    }
+  });
 
 });

--- a/test/common/common.js
+++ b/test/common/common.js
@@ -19,6 +19,7 @@ module.exports = {
 
   // Common Tasks used by tests
   initFramework: function (testName, framework, userWebex) {
+    console.log('In initFramework...');
     // Wait for framework to generate events that indicate it started succesfully
     const started = new Promise((resolve) => {
       this.frameworkStartHandler(testName, framework, resolve);
@@ -34,6 +35,7 @@ module.exports = {
       });
     // While we wait for framework, lets validate the user
     let userInfoIsReady = userWebex.people.get('me');
+    console.log('Waiting for framework initialization to complete...');
     // Now wait until framework is initialized
     return when.all([started, initialized])
       .then(() => {

--- a/test/mongo-tests.js
+++ b/test/mongo-tests.js
@@ -1,0 +1,109 @@
+/* mongo-tests.js
+ *
+ * A set of tests to validate framework functionality
+ * when framework is created using a the mongo storage d
+ */
+
+const Framework = require('../lib/framework');
+const Webex = require('webex');
+const assert = require('assert');
+console.log('Starting bot-tests...');
+
+require('dotenv').config();
+
+let MongoStore = require('../storage/mongo');
+
+// Initialize the framework and user objects once for all the tests
+let framework, userWebex;
+let frameworkOptions = { token: process.env.BOT_API_TOKEN };
+
+// If configured to test the Mongo storage adapter create the config for that
+if (process.env.MONGO_URI) {
+  var mConfig = {};
+  mConfig.mongoUri = process.env.MONGO_URI;
+  if (process.env.MONGO_BOT_STORE) { mConfig.storageCollectionName = process.env.MONGO_BOT_STORE; }
+  if (process.env.MONGO_BOT_METRICS) { mConfig.metricsCollectionName = process.env.MONGO_BOT_METRICS; }
+  if (process.env.MONGO_SINGLE_INSTANCE_MODE) { mConfig.singleInstance = true; }
+  if (typeof process.env.INIT_STORAGE === 'string') {
+    try {
+      frameworkOptions.initBotStorageData = JSON.parse(process.env.INIT_STORAGE);
+    } catch (e) {
+      console.error(`Unable to parse INIT_STORAGE value:${process.env.INIT_STORAGE}`);
+      console.error(`${e.message}`);
+      console.error('Make sure to set this to optional environment to a ' +
+        'properly stringified JSON object in order to test that the storage adapter properly adds it to new bots.');
+      process.exit(-1);
+    }
+  }
+} else {
+  console.error('The mongo storage driver requires the following environment variables:\n' +
+    '* MONGO_URI -- mongo connection URL see https://docs.mongodb.com/manual/reference/connection-string' +
+    '\n\nThe following optional environment variables will also be used if set:\n' +
+    '* MONGO_BOT_STORE -- name of collection for bot storage elements (will be created if does not exist).  Will use "webexBotFramworkStorage" if not set\n' +
+    '* MONGO_BOT_METRICS -- name of a collection to write bot metrics to (will be created if does not exist). bot.writeMetric() calls will fail if not set\n' +
+    '* MONGO_INIT_STORAGE -- stringified ojbect aassigned as the default startup config if non exists yet\n' +
+    '* MONGO_SINGLE_INSTANCE_MODE -- Optimize lookups speeds when only a single bot server instance is running\n\n' +
+    'Also note, the mongodb module v3.4 or higher must be available (this is not included in the framework\'s default dependencies)');
+  process.exit();
+}
+
+if ((typeof process.env.BOT_API_TOKEN === 'string') &&
+  (typeof process.env.USER_API_TOKEN === 'string') &&
+  (typeof process.env.HOSTED_FILE === 'string')) {
+  framework = new Framework(frameworkOptions);
+  userWebex = new Webex({ credentials: process.env.USER_API_TOKEN });
+} else {
+  console.error('Missing required environment variables:\n' +
+    '- BOT_API_TOKEN -- token associatd with an existing bot\n' +
+    '- USER_API_TOKEN -- token associated with an existing user\n' +
+    '- HOSTED_FILE -- url to a file that can be attached to test messages\n' +
+    'The tests will create a new space with the bot and the user');
+  process.exit(-1);
+}
+
+// Load the common module which includes functions and variables
+// shared by multiple tests
+var common = require("./common/common");
+common.setFramework(framework);
+common.setUser(userWebex);
+
+
+// Start up an instance of framework that we will use across multiple tests
+describe('#framework', () => {
+  // Validate that framework starts and that we have a valid user
+  before(() => {
+    if ('mongoUri' in mConfig) {
+      // Load and initalize the mongo storage driver
+      let mongoStore = new MongoStore(mConfig);
+      // Wait for the connection to the DB to initialize before starting framework
+      return mongoStore.initialize()
+        .then(() => framework.storageDriver(mongoStore))
+        .then(() => common.initFramework('framework init', framework, userWebex))
+        .catch((e) => {
+          framework.debug(`Initialization with mongo storage failed: ${e.message}`)
+          return Promise.reject(e);
+        });
+    } else {
+      return Promise.reject(new Error(`Invalid mongo configuration`));
+    }
+  });
+
+  //Stop framework to shut down the event listeners
+  after(() => common.stopFramework('shutdown framework', framework));
+
+  // Test bot interactions in a bot created test space
+  require('./as-bot/bot-created-room-tests.js');
+
+  // Test bot functions for direct messaging
+  // These only work if the test bot and test user already have a direct space
+  require('./common/bot-direct-message-tests.js');
+});
+
+// gracefully shutdown (ctrl-c)
+process.on('SIGINT', function () {
+  framework.debug('stoppping...');
+  framework.stop().then(function () {
+    process.exit();
+  });
+});
+


### PR DESCRIPTION
## v 0.6.0
* Refactored storage adaptor logic
* `framework.storageDriver()` now returns a promise 
* Added new Mongo storage adaptor to support bot storage that persists across server restarts
* Added `initStorage()` method called by the framework when a bot is spawned that loads data in from database or, optionallky creates a default set of key/value pairs specified in the `initBotStorage` elment of the framework's configuration
* Added a `writeMetrics()` method to the storage Adaptor framework, allowing developers who use a persistent storage to write bot activity data for potential engagement level reporting