### PR TITLE
Support "late discovery" of existing bots when a message is sent to them

### DIFF
--- a/docs/example1.md
+++ b/docs/example1.md
@@ -26,14 +26,18 @@ framework.on("initialized", function () {
 });
 
 // A spawn event is generated when the framework finds a space with your bot in it
-framework.on('spawn', function (bot) {
-  if (!framework.initialized) {
+// You can use the bot object to send messages to that space
+// The id field is the id of the framework
+// If addedBy is set, it means that a user has added your bot to a new space
+// Otherwise, this bot was in the space before this server instance started
+framework.on('spawn', function (bot, id, addedBy) {
+  if (!addedBy) {
     // don't say anything here or your bot's spaces will get 
     // spammed every time your server is restarted
-    framework.debug(`While starting up framework found our bot in a space called: ${bot.room.title}`);
+    framework.debug(`Framework created an object for an existing bot in a space called: ${bot.room.title}`);
   } else {
-    // After initialization, a spawn event means your bot got added to 
-    // a new space.   Say hello, and tell users what you do!
+    // addedBy is the ID of the user who just added our bot to a new space, 
+    // Say hello, and tell users what you do!
     bot.say('Hi there, you can say hello to me.  Don\'t forget you need to mention me in a group space!');
   }
 });

--- a/docs/example3.md
+++ b/docs/example3.md
@@ -28,17 +28,22 @@ framework.on("initialized", function () {
 });
 
 // A spawn event is generated when the framework finds a space with your bot in it
-framework.on('spawn', function (bot) {
-  if (!framework.initialized) {
+// You can use the bot object to send messages to that space
+// The id field is the id of the framework
+// If addedBy is set, it means that a user has added your bot to a new space
+// Otherwise, this bot was in the space before this server instance started
+framework.on('spawn', function (bot, id, addedBy) {
+  if (!addedBy) {
     // don't say anything here or your bot's spaces will get 
     // spammed every time your server is restarted
-    framework.debug(`While starting up framework found our bot in a space called: ${bot.room.title}`);
+    framework.debug(`Framework created an object for an existing bot in a space called: ${bot.room.title}`);
   } else {
-    // After initialization, a spawn event means your bot got added to 
-    // a new space.   Say hello, and tell users what you do!
+    // addedBy is the ID of the user who just added our bot to a new space, 
+    // Say hello, and tell users what you do!
     bot.say('Hi there, you can say hello to me.  Don\'t forget you need to mention me in a group space!');
   }
 });
+
 
 var responded = false;
 // say hello

--- a/docs/migrate-from-node-flint.md
+++ b/docs/migrate-from-node-flint.md
@@ -52,6 +52,10 @@ Not all of the functionality in flint has been migrated to the new framework.  A
   * A new framework config option `initBotStorageData` is now available.   Developers can set this to create an initial set of key/value pairs that a bot object will have when it is first spawned.
   * A new mongo storage adaptor is available.  See the Storage Adaptor Changes for more details on how Storage Adaptors now work.
 
+## Spawn events
+Flint would attempt to find all spaces that the bot is part of before completing its initialization.   This could take time and provide inaccurate results, especially for bots that are in over a thousand spaces.  The framework works more like the Webex Teams clients.   By default it tries to find the 100 most recently active spaces at startup (this can be configured using the config option `maxStartupSpaces`).  As the framework processes message:created and membership:created events, it will spawn additional bot objects as needed.   Bots that are spawned due to being added to a new space (since the framework started) will have an additional `addedBy` parameter passed to the ["spawn" event handler](../README.md#"spawn")
+
+
 ## Common migration tasks
 Alternatly, since elements of the bot and trigger objects have also changed, one might just bite the bullet, and do some search and replace.  The biggest migration tasks come from the renaming of flint to framework and the change in structures for the bot and trigger objects.  Common case sensitive search and replace tasks might include
 

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -16,23 +16,27 @@ framework.on("initialized", function () {
 });
 
 // A spawn event is generated when the framework finds a space with your bot in it
-framework.on('spawn', function (bot) {
-  if (!framework.initialized) {
+// You can use the bot object to send messages to that space
+// The id field is the id of the framework
+// If addedBy is set, it means that a user has added your bot to a new space
+// Otherwise, this bot was in the space before this server instance started
+framework.on('spawn', function (bot, id, addedBy) {
+  if (!addedBy) {
     // don't say anything here or your bot's spaces will get 
     // spammed every time your server is restarted
-    framework.debug(`While starting up framework found our bot in a space called: ${bot.room.title}`);
+    framework.debug(`Framework created an object for an existing bot in a space called: ${bot.room.title}`);
   } else {
-    // After initialization, a spawn event means your bot got added to 
-    // a new space.   Say hello, and tell users what you do!
+    // addedBy is the ID of the user who just added our bot to a new space, 
+    // Say hello, and tell users what you do!
     bot.say('Hi there, you can say hello to me.  Don\'t forget you need to mention me in a group space!');
   }
 });
 ```
 
-Most of the framework's functionality is based around the framework.hears function. This
+Most of the framework's functionality is based around the `framework.hears()` function. This
 defines the phrase or pattern the bot is listening for and what actions to take
-when that phrase or pattern is matched. The framework.hears function gets a callback
-than includes two objects. The bot object, and the trigger object.
+when that phrase or pattern is matched. The `framework.hears()` function gets a callback
+than includes two objects. The bot object, and the trigger object, and the id of the framework.
 
 The bot object is a specific instance of the Bot class associated with the Webex Teams space that triggered the framework.hears call.  
 The trigger object provides details about the person and room and message, that caused the framework.hears function to be triggered.
@@ -40,7 +44,7 @@ The trigger object provides details about the person and room and message, that 
 A simple example of a framework.hears() function setup:
 
 ```js
-framework.hears(phrase, function(bot, trigger) {
+framework.hears(phrase, function(bot, trigger, id) {
   bot.<command>
     .then(function(returnedValue) {
       // do something with returned value

--- a/docs/version-history.md
+++ b/docs/version-history.md
@@ -1,3 +1,8 @@
+## v 0.7.0
+* Webex list APIs such as /rooms and /memberships do not perform well for applications that belong in over 1000 spaces.   In order to support popular bots the framework will now do "late spawning" of bots that existed in spaces before the server started, but were not discovered until after the framework completed its initialization.
+* Added `maxStartupSpaces` parameter to framework options to set the number of bot objects to "pre-spawn".   The default is 100.  This is similar to how Webex Teams clients work when starting getting only the 100 or so "most recent" spaces and then discovering other spaces "on the fly" as messages are sent to them.
+* As a consquence to this, existing samples that used the value of `framework.initialized` in the `spawn` event handler to differentiate between spaces that were discovered at startup vs. spaces that the bot has newly been added to, needed to change since it is now possible that bots that were in spaces prior to the server startup are spawned after the framework is initialized.  The new best practice is to look for the presence of the `addedBy` parameter in the `spawn` event handler.  If this is is set, it means that this spawn event was generated in response to a new membership rather than a new message event, which means that the bot was just added to a new space.   Applications may use this to add logic to have the bot introduce itself when it is first added to a space (but not everytime it is spawned, since that would spam users every time the server is restarted)
+
 ## v 0.6.1
 * Bug fixes to ensure initStorage completes before 'spawned' event is emitted.
 

--- a/lib/framework.js
+++ b/lib/framework.js
@@ -51,6 +51,10 @@ function Framework(options) {
    * @property {string} token - Webex Token.
    * @property {string} [webhookUrl] - URL that is used for Webex API to send callbacks.  If not set events are received via websocket
    * @property {string} [webhookSecret] - If specified, inbound webhooks are authorized before being processed. Ignored if webhookUrl is not set.
+   * @property {number}[maxStartupSpaces=100] - If specified, the maximum number of spaces with our bot that the framework will discover during startup.  
+        Max value for this parameter is 1000.  Setting this emulates the legacy flint startup behavior, otherwise 
+        bots are discovered "just in time" if they are messaged in existing spaces or added to new spaces, which is closer
+        to the way webex teams clients also work.  See the [Spawn Event docs](#"spawn") to discover how to handle them differently
    * @property {string} [messageFormat=text] - Default Webex message format to use with bot.say().
    * @property {object} [initBotStorageData={}] - Initial data for new bots to put into storage. 
    * @property {string} [id=random] - The id this instance of Framework uses.
@@ -93,7 +97,16 @@ function Framework(options) {
   this.webhook = {};
   this.cardsWebhook = {};
 
+  // Check if we should set up any "default" storage data for newly discovered bots
   this.initBotStorageData = (typeof options.initBotStorageData === 'object') ? options.initBotStorageData : {};
+
+  // Check how many spaces to discover upon startup
+  if ((typeof options.maxStartupSpaces === 'number') &&
+    (options.maxStartupSpaces >= 0) && (options.maxStartupSpaces <= 1000)) {
+    this.maxStartupSpaces = options.maxStartupSpaces;
+  } else {
+    this.maxStartupSpaces = 100;
+  }
 
   // register internal events
   this.on('error', err => {
@@ -340,38 +353,33 @@ Framework.prototype.start = function () {
             })
 
             .then(() => {
-              if (this.options.webhookUrl) {
-                // Create the webex teams "firehose" webhook for all events
-                let newWebhook = {
-                  resource: 'all',
-                  event: 'all',
-                  targetUrl: this.options.webhookUrl,
-                  name: u.base64encode(this.options.webhookUrl.split('/')[2] + ' ' + this.email)
-                };
-                if (this.options.webhookSecret) {
-                  newWebhook.secret = this.options.webhookSecret;
-                }
-                this.webex.webhooks.create(newWebhook)
-                  .then(webhook => {
-                    // Create a webhook for attachmentActions which happen when a user hits a "Submit"
-                    // button in a card we posted.   This is not included in the "firehose" webhook
-                    this.webhook = webhook;
-                    newWebhook.resource = 'attachmentActions';
-                    newWebhook.event = 'created';
-                    return this.webex.webhooks.create(newWebhook);
-                  })
-                  .then(webhook => {
-                    this.cardsWebhook = webhook;
-                    return when(webhook);
-                  })
-                  .catch((err) => {
-                    this.webhook = false;
-                    return when(false);
-                  });
-              } else {
-                this.webhook = false;
-                return when(false);
+              // Create the webex teams "firehose" webhook for all events
+              let newWebhook = {
+                resource: 'all',
+                event: 'all',
+                targetUrl: this.options.webhookUrl,
+                name: u.base64encode(this.options.webhookUrl.split('/')[2] + ' ' + this.email)
+              };
+              if (this.options.webhookSecret) {
+                newWebhook.secret = this.options.webhookSecret;
               }
+              this.webex.webhooks.create(newWebhook)
+                .then(webhook => {
+                  // Create a webhook for attachmentActions which happen when a user hits a "Submit"
+                  // button in a card we posted.   This is not included in the "firehose" webhook
+                  this.webhook = webhook;
+                  newWebhook.resource = 'attachmentActions';
+                  newWebhook.event = 'created';
+                  return this.webex.webhooks.create(newWebhook);
+                })
+                .then(webhook => {
+                  this.cardsWebhook = webhook;
+                  return when(webhook);
+                })
+                .catch((err) => {
+                  console.error(`Error setting webhooks during initialization: ${err.message}`);
+                  return when(this.webhook = false);
+                });
             });
         } else {
           // There was no webhookUrl specified so we will use websockets instead
@@ -425,35 +433,43 @@ Framework.prototype.start = function () {
  */
 Framework.prototype.initialize = function () {
   // spawn bots in existing rooms at startup
-  return this.webex.memberships.list()
-    .then(memberships => {
+  if (this.maxStartupSpaces) {
+    return this.webex.memberships.list(
+      {max: this.maxStartupSpaces}
+    )
+      .then(memberships => {
 
-      // create batch
-      var batch = _.map(memberships.items, m => {
-        return () => this.spawn(m);
+        // create batch
+        var batch = _.map(memberships.items, m => {
+          return () => this.spawn(m);
+        });
+
+        // run batch
+        return sequence(batch)
+          .then(() => when(true))
+          .catch(err => {
+            this.debug(err.stack);
+            return when(true);
+          });
+      })
+
+      .then(() => {
+        /**
+         * Framework initialized event.
+         *
+         * @event initialized
+         * @property {string} id - Framework UUID
+         */
+        this.emit('initialized', this.id);
+        this.initialized = true;
+        return when(true);
       });
 
-      // run batch
-      return sequence(batch)
-        .then(() => when(true))
-        .catch(err => {
-          this.debug(err.stack);
-          return when(true);
-        });
-    })
-
-    .then(() => {
-      /**
-       * Framework initialized event.
-       *
-       * @event initialized
-       * @property {string} id - Framework UUID
-       */
-      this.emit('initialized', this.id);
-      this.initialized = true;
-      return when(true);
-    });
-
+  } else {
+    this.emit('initialized', this.id);
+    this.initialized = true;
+    return when(true);
+  }
 };
 
 /**
@@ -1541,19 +1557,22 @@ Framework.prototype.onMembershipDeleted = function (membership, actorId) {
 
 /**
  * Process a new Message event.
+ * 
+ * This method is called internally by the Framework in response
+ * to a message:created event in a space where our bot is a member
  *
  * @function
  * @memberof Framework
  * @private
- * @param {Object} tembership - Webex Team Membership Object
+ * @param {Object} message - Webex Team Message Object
  * @returns {Promise}
  */
 Framework.prototype.onMessageCreated = function (message) {
   var bot = _.find(this.bots, bot => bot.room.id === message.roomId);
-  if (bot) bot.lastActivity = moment().utc().format();
 
   // if bot found...
   if (bot) {
+    bot.lastActivity = moment().utc().format();
     // check if message is from bot...
     // using the bot's ID instead of the email guarantees this will work
     // even if the bot's name changes (eg: mybot@sparkbot.io -> mybot@webex.bot)
@@ -1662,15 +1681,6 @@ Framework.prototype.onMessageCreated = function (message) {
           bot.emit('files', bot, trigger, bot.id);
         }
 
-        // check if message is from bot...
-        // using the bot's ID instead of the email guarantees this will work
-        // even if the bot's name changes (eg: mybot@sparkbot.io -> mybot@webex.bot)
-        // No longer needed?   I think this check happens much earlier now..
-        // if (trigger.personId === bot.person.id) {
-        //   // ignore messages from bot
-        //   return when(false);
-        // }
-
         // if trigger text present...
         if (trigger.text) {
 
@@ -1735,7 +1745,28 @@ Framework.prototype.onMessageCreated = function (message) {
 
   // else, bot not found...
   else {
-    return when(false);
+    // It is is possible that not all rooms we are in were discovered on startup
+    // and that this message was sent in one of those rooms, do a "just in time" spawn
+    // First validate that we have a memmbership in the space
+    return this.webex.memberships.list(
+      {
+        roomId: message.roomId,
+        personId: this.person.id
+      })
+      .then((memberships) => this.spawn(memberships.items[0]))
+      .then((isBot) => {
+        if (isBot) {
+          // recursively call this method to process the message
+          return this.onMessageCreated(message);
+        } else {
+          return when(false);
+        }
+      })
+      .catch((e) => {
+        this.debug('onMessageCreated() got a message in a space where we have ' +
+          `no bot.  Error doing late discovery: "${e.message}".  Message ignored.`);
+        return when(false);
+      });
   }
 };
 
@@ -1760,7 +1791,28 @@ Framework.prototype.onAttachmentActions = function (attachmentAction) {
       });
     // else, bot not found...
   } else {
-    return when(false);
+    // It is is possible that not all rooms we are in were discovered on startup
+    // and that this message was sent in one of those rooms, do a "just in time" spawn
+    // First validate that we have a memmbership in the space
+    return this.webex.memberships.list(
+      {
+        roomId: attachmentAction.roomId,
+        personId: this.person.id
+      })
+      .then((memberships) => this.spawn(memberships.items[0]))
+      .then((isBot) => {
+        if (isBot) {
+          // recursively call this method to process the message
+          return this.onAttachmentActions(attachmentAction);
+        } else {
+          return when(false);
+        }
+      })
+      .catch((e) => {
+        this.debug('onAttachmentActions() got a message in a space where we have ' +
+          `no bot.  Error doing late discovery: "${e.message}".  Message ignored.`);
+        return when(false);
+      });
   }
 };
 
@@ -1903,31 +1955,46 @@ Framework.prototype.spawn = function (membership, actorId) {
        * @event spawn
        * @property {object} bot - Bot Object
        * @property {string} id - Framework UUID
-       * @property {string} addedBy - ID of user who added bot to space if available
+       * @property {string} addedBy - ID of user who added bot to space if available.
        * 
-       * Bots are typically spawned in one of two ways
-       * 1) When the framework first starts it looks for spaces that 
-       *    our bot is already part of.  When discovered a new bot is spawned
-       * 2) After the framework has started, if a user adds our bot to a space
-       *    a membership:created event occurs which also spawns a bot
-       * 
-       * In the latter case, we pass the actorId associated with the membership:created
-       * event.  This allows bots to do something with info about the user who
-       * added them when they are first spawned.
+       * Bots are typically spawned in one of three ways:
+       * 1) When the framework first starts it can look for up to 
+       *    options.maxStartupSpaces spaces that 
+       *    our bot is already part of.  When discovered a new bot is spawned.
+       *    No addedBy parameter will be passed in this case and the 
+       *    `framework.initialized` variable will be false.
+       * 2) After the framework has started if a user sends
+       *    a message to a bot in an existing space that was not discovered during startup,
+       *    a bot object is spawned for the "just in time" discovered space.  Developers
+       *    should never assume that all possible spaces were discovered during 
+       *    the framework's startup.
+       *    No addedBy parameter will be passed in this case and the 
+       *    framework.initialized variable will be true.
+       * 3) After the framework has started, if a user adds our bot to a new space
+       *    a membership:created event occurs which also spawns a bot.  The 
+       *    framework will inlcude the addedBy parameter and framework.initialized
+       *    will be true.   A best practice In these cases, is to include application
+       *    logic for the bot to "introduce itself" and/or do something with the
+       *    information about the user who created the bot's membership
+       *    
        *
        * @example
        * // DM the user who added bot to a group space
        * framework.on('spawn', function(bot, flintId, addedBy) {
-       *   if (!framework.initialized) {
+       *     if (!addedById) {
        *      // don't say anything here or your bot's spaces will get
        *      // spammed every time your server is restarted
-       *      framework.debug(`While starting up our bot was found '+
-       *        in a space called: ${bot.room.title}`);
+       *      framework.debug(`Framework spawned a bot object in existing
+       *         space: ${bot.room.title}`);
        *   } else {
        *     if ((bot.room.type === 'group') && (addedBy)) {
-       *       bot.dm(addedBy, 'I see you added me to the the space '  + bot.room.title + ',
-       *         but I'm not allowed in group spaces.  We can talk here if you like.');
+       *       bot.dm(addedBy, `I see you added me to the the space "${bot.room.title}", ` +
+       *         `but I am not allowed in group spaces.  We can talk here if you like.`);
        *       bot.exit();
+       *     } else {
+       *       bot.say(`Thanks for adding me to this space.  Here is what I can do...`);
+       *     }
+       *   }
        * });
        *
        */
@@ -2180,7 +2247,7 @@ Framework.prototype.storageDriver = function (driver) {
     Bot.prototype.initStorage = function (framework) {
       if ((typeof this.room && 'object') && (typeof this.room.id === 'string')) {
         var id = this.room.id;
-        return driver.initStorage.call(driver, id, framework.initialized, framework.initBotStorageData);
+        return driver.initStorage.call(driver, id, framework.initBotStorageData);
       } else {
         return when.reject(new Error('bot.initStorage() called when bot does not have a valid room object'));
       }

--- a/package.json
+++ b/package.json
@@ -1,12 +1,13 @@
 {
   "name": "webex-node-bot-framework",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "description": "Webex Teams Bot Framework for Node JS",
   "main": "index.js",
   "scripts": {
     "test": "node_modules/.bin/mocha test/bot-tests.js --exit",
     "test-as-user": "node_modules/.bin/mocha test/integration-tests.js --exit",
     "test-mongo": "node_modules/.bin/mocha test/mongo-tests.js --exit",
+    "test-late-discovery": "node_modules/.bin/mocha test/late-discovery-tests.js --exit",
     "build": "cd docs && ./build.sh && cd .."
   },
   "repository": {

--- a/storage/memory.js
+++ b/storage/memory.js
@@ -36,11 +36,10 @@ module.exports = exports = function () {
      *
      * @function
      * @param {String} id - Room/Conversation/Context ID
-     * @param {boolean} frameworkInitialized - false during framework startup
      * @param {object} initBotData - object that contains the key/value pairs that should be set for new bots
      * @returns {(Promise.<Object>)} - bot's initial config data
      */
-    initStorage: function (id, frameworkInitialized, initBotData) {
+    initStorage: function (id, initBotData) {
       if (typeof id === 'string') {
         // if id does not exist, create
         if (!memStore[id]) {

--- a/storage/redis.js
+++ b/storage/redis.js
@@ -47,22 +47,18 @@ module.exports = exports = function (connectionUrl) {
      *
      * @function
      * @param {String} id - Room/Conversation/Context ID
-     * @param {boolean} frameworkInitialized - false during framework startup
      * @param {object} initBotData - object that contains the key/value pairs that should be set for new bots
      * @returns {(Promise.<Object>} - bot's initial config data
      */
-    initStorage: function (id, frameworkInitialized, initBotData) {
-      if (frameworkInitialized) {
-        // see if any exising data is in redis...
-      } else {
-        // Storage adaptors with persistent memory will add the initial 
-        // data only for "new" bots which are created after the framewor
-        // is initialized.   
-        if ((initBotData) && (typeof initBotData === 'object')) {
-          // Add this data to redis for this bot/space
-        }
-        return when(initBotData);
+    initStorage: function (id, initBotData) {
+      // TO BE IMPLEMENTED
+      // Check if data already exists in this space
+      // If so return it here
+      // If not add each key/value pair in the initBotData
+      if ((initBotData) && (typeof initBotData === 'object')) {
+        // Add this data to redis for this bot/space
       }
+      return when(initBotData);
     },
 
     /**

--- a/storage/template.js
+++ b/storage/template.js
@@ -37,13 +37,12 @@ module.exports = exports = function () {
      *
      * @function
      * @param {String} id - Room/Conversation/Context ID
-     * @param {boolean} frameworkInitialized - false during framework startup
      * @param {object} initBotData - object that contains the key/value pairs that should be set for new bots
      * @returns {(Promise.<Object>} - bot's initial config data
      */
-    initStorage: function (id, frameworkInitialized, initBotData) {
-      // if framework is initialized check store for id
-      // if not found or framework is not initizlied set the initial bot data passed in
+    initStorage: function (id, initBotData) {
+      // check if there is existing data for this id in the persistent store
+      // if not found, set the initial bot data passed in
       // if success, return promise that resolves to initBotData
       // if failure, returns a rejected promise
     },

--- a/test/bot-tests.js
+++ b/test/bot-tests.js
@@ -22,7 +22,7 @@ if ((typeof process.env.BOT_API_TOKEN === 'string') &&
     } catch (e) {
       console.error(`Unable to parse INIT_STORAGE value:${process.env.INIT_STORAGE}`);
       console.error(`${e.message}`);
-      console.error('Make sure to set this to optional environment to a '+
+      console.error('Make sure to set this to optional environment to a ' +
         'properly stringified JSON object in order to test that the storage adapter properly adds it to new bots.');
       process.exit(-1);
     }

--- a/test/late-discovery-tests.js
+++ b/test/late-discovery-tests.js
@@ -1,0 +1,107 @@
+/* late-discovery-tests.js
+ *
+ * A set of tests to validate framework functionality
+ * can create bot objects on the fly as opposed
+ * to on startup.
+ * 
+ * These tests require that the bot exist in a one on one
+ * space with the test user
+ */
+
+const Framework = require('../lib/framework');
+const Webex = require('webex');
+console.log('Starting late-discovery-tests...');
+
+// Initialize the framework and user objects once for all the tests
+let framework, userWebex;
+require('dotenv').config();
+if ((typeof process.env.BOT_API_TOKEN === 'string') &&
+  (typeof process.env.USER_API_TOKEN === 'string') &&
+  (typeof process.env.HOSTED_FILE === 'string')) {
+  frameworkOptions = { token: process.env.BOT_API_TOKEN };
+  // This is the key to these tests, we wont discover any spaces on 
+  // startup, just when a message:created event occurs
+  frameworkOptions.maxStartupSpaces = 0;
+  framework = new Framework(frameworkOptions);
+  userWebex = new Webex({ credentials: process.env.USER_API_TOKEN });
+} else {
+  console.error('Missing required environment variables:\n' +
+    '- BOT_API_TOKEN -- token associatd with an existing bot\n' +
+    '- USER_API_TOKEN -- token associated with an existing user\n' +
+    '- HOSTED_FILE -- url to a file that can be attached to test messages\n' +
+    'The tests will create a new space with the bot and the user');
+  process.exit(-1);
+}
+
+// Load the common module which includes functions and variables
+// shared by multiple tests
+var common = require("./common/common");
+common.setFramework(framework);
+common.setUser(userWebex);
+let assert = common.assert;
+let validator = common.validator;
+let when = common.when;
+
+
+
+// Start up an instance of framework that we will use across multiple tests
+describe('#framework', () => {
+  let testName = 'creates a bot just in time after message';
+  // Validate that framework starts and that we have a valid user
+  before(() => common.initFramework('framework init', framework, userWebex));
+
+  // Setup the promises for the events that come from user input that mentions a bot
+  // beforeEach(() => {
+  //   message = {};
+  //   // Wait for the events associated with a new message before completing test..
+  //   eventsData = {};
+  //   messageCreatedEvent = new Promise((resolve) => {
+  //     common.frameworkMessageCreatedEventHandler(testName, framework, eventsData, resolve);
+  //   });
+  //   frameworkMessageEvent = new Promise((resolve) => {
+  //     common.frameworkMessageHandler(testName, framework, eventsData, resolve);
+  //   });
+  // });
+
+  //Stop framework to shut down the event listeners
+  after(() => common.stopFramework('shutdown framework', framework));
+
+  // Test bot functions for direct messaging
+  // These only work if the test bot and test user already have a direct space
+  it.only('creates a bot just in time after message', () => {
+    // Wait for the hears event associated with the input text
+    const heard = new Promise((resolve) => {
+      framework.hears(/^hi.*/igm, (b, t) => {
+        framework.debug('Bot heard message  that user posted');
+        resolve(true);
+      });
+    });
+
+    // As the user, send the message, mentioning the bot
+    return userWebex.messages.create({
+      toPersonId: framework.person.id,
+      markdown: `Hi, this is a message with **no mentions**.`
+    })
+      .then((m) => {
+        message = m;
+        assert(validator.isMessage(message),
+          'create message did not return a valid message');
+        // Wait for all the event handlers and the heard handler to fire
+        return when(heard);
+        //return when.all([messageCreatedEvent, frameworkMessageEvent, heard]);
+      })
+      .catch((e) => {
+        console.error(`${testName} failed: ${e.message}`);
+        return Promise.reject(e);
+      });
+  });
+});
+
+// gracefully shutdown (ctrl-c)
+process.on('SIGINT', function () {
+  framework.debug('stoppping...');
+  framework.stop().then(function () {
+    process.exit();
+  });
+});
+

--- a/test/mongo-tests.js
+++ b/test/mongo-tests.js
@@ -6,7 +6,6 @@
 
 const Framework = require('../lib/framework');
 const Webex = require('webex');
-const assert = require('assert');
 console.log('Starting bot-tests...');
 
 require('dotenv').config();
@@ -80,7 +79,7 @@ describe('#framework', () => {
         .then(() => framework.storageDriver(mongoStore))
         .then(() => common.initFramework('framework init', framework, userWebex))
         .catch((e) => {
-          framework.debug(`Initialization with mongo storage failed: ${e.message}`)
+          framework.debug(`Initialization with mongo storage failed: ${e.message}`);
           return Promise.reject(e);
         });
     } else {


### PR DESCRIPTION
## v 0.7.0
* Webex list APIs such as /rooms and /memberships do not perform well for applications that belong in over 1000 spaces.   In order to support popular bots the framework will now do "late spawning" of bots that existed in spaces before the server started, but were not discovered until after the framework completed its initialization.
* Added `maxStartupSpaces` parameter to framework options to set the number of bot objects to "pre-spawn".   The default is 100.  This is similar to how Webex Teams clients work when starting getting only the 100 or so "most recent" spaces and then discovering other spaces "on the fly" as messages are sent to them.
* As a consquence to this, existing samples that used the value of `framework.initialized` in the `spawn` event handler to differentiate between spaces that were discovered at startup vs. spaces that the bot has newly been added to, needed to change since it is now possible that bots that were in spaces prior to the server startup are spawned after the framework is initialized.  The new best practice is to look for the presence of the `addedBy` parameter in the `spawn` event handler.  If this is is set, it means that this spawn event was generated in response to a new membership rather than a new message event, which means that the bot was just added to a new space.   Applications may use this to add logic to have the bot introduce itself when it is first added to a space (but not everytime it is spawned, since that would spam users every time the server is restarted)