### PR TITLE
mongo bot.store complete write before returning

### DIFF
--- a/docs/version-history.md
+++ b/docs/version-history.md
@@ -1,3 +1,6 @@
+## v 0.7.1
+* Bug fixes to ensure bot.store() fully completes write to persistent store before returning
+
 ## v 0.7.0
 * Webex list APIs such as /rooms and /memberships do not perform well for applications that belong in over 1000 spaces.   In order to support popular bots the framework will now do "late spawning" of bots that existed in spaces before the server started, but were not discovered until after the framework completed its initialization.
 * Added `maxStartupSpaces` parameter to framework options to set the number of bot objects to "pre-spawn".   The default is 100.  This is similar to how Webex Teams clients work when starting getting only the 100 or so "most recent" spaces and then discovering other spaces "on the fly" as messages are sent to them.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webex-node-bot-framework",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Webex Teams Bot Framework for Node JS",
   "main": "index.js",
   "scripts": {

--- a/storage/mongo.js
+++ b/storage/mongo.js
@@ -244,6 +244,7 @@ class MongoStore {
       }
       return this.botStoreCollection.replaceOne(
         { _id: id }, this.memStore[id], { upsert: true })
+        .then(() => when(value))
         .catch((e) => {
           return when.reject(new Error(`Failed DB storeConfig update spaceId: "${id}": ${e.message}`));
         });
@@ -348,7 +349,7 @@ class MongoStore {
       return when.reject(new Error(`Failed to forget ${key}.  Invalid bot object.`));
     }
 
-    if ((!((this.config.singleInstance) || (skipDbWrites))) && (typeof key !== 'undefined')) {
+    if (!((this.config.singleInstance) || (skipDbWrites))) {
       return this.botStoreCollection.findOne({ _id: id })
         .then((remoteConfig) => {
           this.memStore[id] = remoteConfig;


### PR DESCRIPTION
## v 0.7.1
* Bug fixes to ensure bot.store() fully completes write to persistent store before returning
