### PR TITLE
Mongo update one

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -24,7 +24,7 @@
         "--timeout",
         "90000",
         "--colors",
-        "${workspaceFolder}/test/integration-tests.js"
+        "${workspaceFolder}/test/bot-tests.js"
       ],
       "internalConsoleOptions": "openOnSessionStart"
     }

--- a/docs/version-history.md
+++ b/docs/version-history.md
@@ -1,3 +1,8 @@
+## v 1.0.2
+* Fixed some race conditions caused by problems when events happen very fast, for example the memberships and message events when a one-on-one space is created.  Sometimes the flint.hears() handler could be called before the flint.spawn() handler finished processing.
+* Mongo now uses updateOne to modify just the one field in a bot.store() call.  Previously it updated the whole document with replaceOne().  This prevents one element from being stored if bot.store() is called from another handler before the first previous one returns.
+* flint.spawn() could be called multiple times on room creation.  It now checks if a spawn is in progress for a room and ignores subsequent requests.
+
 ## v 1.0.1
 * Bug fix. Bot membership deletes in spaces that were never spawned are ignored.   (It's too late to spawn a bot when we can't get any room details)
 

--- a/lib/framework.js
+++ b/lib/framework.js
@@ -90,6 +90,7 @@ function Framework(options) {
   this.logMax = 1000;
   this.lexicon = [];
   this.bots = [];
+  this.roomsSpawningNow = [];
   this.webex = {};
   this.webhook = {};
   this.cardsWebhook = {};
@@ -801,7 +802,7 @@ Framework.prototype.onMembershipCreated = function (membership, actorId) {
       // First validate that we have a memmbership in the space
       return this.webex.memberships.list(
         {
-          roomId: room.id,
+          roomId: membership.roomId,
           personId: this.person.id
         })
         .then((memberships) => this.spawn(memberships.items[0]), actorId)
@@ -1294,15 +1295,21 @@ Framework.prototype.spawn = function (membership, actorId) {
 
   // validate params
   if ((typeof memberships !== 'object') && (typeof membership.roomId !== 'string')) {
-    this.debug('A bot for acount "%s" could not spawn as membership room id not valid', this.email);
+    this.debug('A bot for account "%s" could not spawn as membership room id not valid', this.email);
     return when(false);
   }
   let roomId = membership.roomId;
 
+  // validate that we aren't in the process of spawning a bot for this space already
+  if (this.roomsSpawningNow.indexOf(roomId) >= 0) {
+    // Race condition while attempting to spawn room, let the previous spawn finish
+    return when(false);
+  }
+
   // validate bot is not already assigned to room
   var foundBot = _.find(this.bots, bot => (bot.room.id === roomId));
   if (foundBot) {
-    this.debug('A bot for acount "%s" could not spawn as bot already exists in room', this.email);
+    this.debug(`framework.spawn() got a request to spawn in spaceId ${membership.roomId}.  Bot already has been spawned here. Ignorning.`);
     return when(false);
   }
 
@@ -1311,6 +1318,9 @@ Framework.prototype.spawn = function (membership, actorId) {
   // assign membership properties to bot object
   newBot.membership = membership;
   newBot.isModerator = membership.isModerator;
+
+  // prevent any "late spawning" of this space while we are asyncronously building our bot object
+  this.roomsSpawningNow.push(roomId);
 
   // get room that bot is spawning in
   return this.webex.rooms.get(roomId)
@@ -1351,6 +1361,9 @@ Framework.prototype.spawn = function (membership, actorId) {
 
       // add bot to array of bots
       this.bots.push(newBot);
+
+      // Remove this space from "in spawning process" array
+      this.roomsSpawningNow = _.remove(this.roomsSpawningNow, roomId);
 
       /**
        * Bot Spawned.
@@ -1415,6 +1428,8 @@ Framework.prototype.spawn = function (membership, actorId) {
       console.error(`Failed spawning a bot in roomId: ${roomId}.  Error: ${err.message}`);
       // remove reference
       newBot = {};
+      // Remove this space from "in spawning process" array
+      this.roomsSpawningNow = _.remove(this.botsSpawningNow, roomId);
 
       return when(false);
     });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webex-node-bot-framework",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Webex Teams Bot Framework for Node JS",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
## v 1.0.2
* Fixed some race conditions caused by problems when events happen very fast, for example the memberships and message events when a one-on-one space is created.  Sometimes the flint.hears() handler could be called before the flint.spawn() handler finished processing.
* Mongo now uses updateOne to modify just the one field in a bot.store() call.  Previously it updated the whole document with replaceOne().  This prevents one element from being stored if bot.store() is called from another handler before the first previous one returns.
* flint.spawn() could be called multiple times on room creation.  It now checks if a spawn is in progress for a room and ignores subsequent requests.
